### PR TITLE
Add support for HTML comments

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -182,6 +182,7 @@ let s:delimiterMap = {
     \ 'hercules': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hog': { 'left': '#' },
     \ 'hostsaccess': { 'left': '#' },
+    \ 'html': { 'left': '<!--','right': '-->' },
     \ 'htmlcheetah': { 'left': '##' },
     \ 'htmldjango': { 'left': '<!--','right': '-->', 'leftAlt': '{#', 'rightAlt': '#}' },
     \ 'htmlos': { 'left': '#', 'right': '/#' },


### PR DESCRIPTION
Previously I NERDCommenter tried to use C-style comments (/\* */) for my HTML files, this commit fixes this.
