### PR TITLE
corrected comment delimiter for liquid filetype (rebased over new version)

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -208,7 +208,7 @@ let s:delimiterMap = {
     \ 'ldif': { 'left': '#' },
     \ 'lilo': { 'left': '#' },
     \ 'lilypond': { 'left': '%' },
-    \ 'liquid': { 'left': '{%', 'right': '%}' },
+    \ 'liquid': { 'left': '{% comment %}', 'right': '{% endcomment %}' },
     \ 'lisp': { 'left': ';', 'leftAlt': '#|', 'rightAlt': '|#' },
     \ 'llvm': { 'left': ';' },
     \ 'lotos': { 'left': '(*', 'right': '*)' },


### PR DESCRIPTION
The comment delimiter for liquid filetype is erroneously registered as '{%' and '%}' while the correct delimiter should be '{% comment %}' and '{% endcomment %}'

This pull request fixes that.
