### PR TITLE
Default alignment option + ability to align at index 0.

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -429,6 +429,9 @@ then the script would do a sexy comment on the last visual selection.
                                       uncommenting.
 |'NERDCompactSexyComs'|               Specifies whether to use the compact
                                       style sexy comments.
+|'NERDDefaultAlign'|                  Specifies the default aligment to use,
+                                      one of 'none', 'left', 'start', or
+                                      'both'.
 
 ------------------------------------------------------------------------------
 4.3 Options details                                    *NERDComOptionsDetails*
@@ -602,6 +605,14 @@ Otherwise they would become: >
 If you want the spaces to be removed only if |'NERDSpaceDelims'| is set then
 set NERDRemoveExtraSpaces to 0.
 
+Note: When using 'start' as the default alignment, the enabling of
+NERDRemoveExtraSpaces will still result in the removal of a space after the
+delimiter.  This can be undesirable since aligning the delimiters at the very
+start of the line (index 0) will usually result in spaces between the comment
+delimiters and the text which probably shouldn't be removed.  So when using
+'start' as the default alignment, take care to also disable
+NERDRemoveExtraSpaces.
+
 ------------------------------------------------------------------------------
                                                                   *'NERDLPlace'*
                                                                   *'NERDRPlace'*
@@ -658,7 +669,17 @@ as opposed to this: >
 <
 If you want spaces to be added then set NERDSpaceDelims to 1 in your vimrc.
 
-See also |'NERDRemoveExtraSpaces'|.
+
+------------------------------------------------------------------------------
+                                                             *'NERDDefaultAlign'*
+Values: 'none', 'left', 'start', 'both'
+Default 'none'.
+
+Specifies the default alignment to use when inserting comments.
+
+Note: When using 'start' as the default alignment be sure to disable
+NERDRemoveExtraSpaces.  See the note at the bottom of |NERDRemoveExtraSpaces|
+for more details.
 
 ------------------------------------------------------------------------------
                                                          *'NERDCompactSexyComs'*

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -429,7 +429,7 @@ then the script would do a sexy comment on the last visual selection.
                                       uncommenting.
 |'NERDCompactSexyComs'|               Specifies whether to use the compact
                                       style sexy comments.
-|'NERDDefaultAlign'|                  Specifies the default aligment to use,
+|'NERDDefaultAlign'|                  Specifies the default alignment to use,
                                       one of 'none', 'left', 'start', or
                                       'both'.
 
@@ -669,6 +669,7 @@ as opposed to this: >
 <
 If you want spaces to be added then set NERDSpaceDelims to 1 in your vimrc.
 
+See also |'NERDRemoveExtraSpaces'|.
 
 ------------------------------------------------------------------------------
                                                              *'NERDDefaultAlign'*

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -62,6 +62,7 @@ call s:InitVariable("g:NERDRemoveExtraSpaces", 1)
 call s:InitVariable("g:NERDRPlace", "<]")
 call s:InitVariable("g:NERDSpaceDelims", 0)
 call s:InitVariable("g:NERDDelimiterRequests", 1)
+call s:InitVariable("g:NERDDefaultAlign", "none")
 
 let s:NERDFileNameEscape="[]#*$%'\" ?`!&();<>\\"
 "vf ;;dA:hcs"'A {j^f(lyi(k$p0f{a A }0f{a 'left':jdd^
@@ -629,13 +630,13 @@ endfunction
 " Args:
 "   -forceNested: a flag indicating whether the called is requesting the comment
 "    to be nested if need be
-"   -align: should be "left" or "both" or "none"
+"   -align: should be "left", "start", "both" or "none"
 "   -firstLine/lastLine: the top and bottom lines to comment
 function s:CommentLines(forceNested, align, firstLine, lastLine)
     " we need to get the left and right indexes of the leftmost char in the
     " block of of lines and the right most char so that we can do alignment of
     " the delimiters if the user has specified
-    let leftAlignIndx = s:LeftMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
+    let leftAlignIndx = a:align == "start" ? 0 : s:LeftMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
     let rightAlignIndx = s:RightMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
 
     " gotta add the length of the left delimiter onto the rightAlignIndx cos
@@ -663,7 +664,7 @@ function s:CommentLines(forceNested, align, firstLine, lastLine)
 
             " check if we can comment this line
             if !isCommented || g:NERDUsePlaceHolders || s:Multipart()
-                if a:align == "left" || a:align == "both"
+                if a:align == "left" || a:align == "start" || a:align == "both"
                     let theLine = s:AddLeftDelimAligned(s:Left({'space': 1}), theLine, leftAlignIndx)
                 else
                     let theLine = s:AddLeftDelim(s:Left({'space': 1}), theLine)
@@ -867,6 +868,12 @@ endfunction
 "   -firstLine/lastLine: the top and bottom lines to comment
 function s:CommentLinesToggle(forceNested, firstLine, lastLine)
     let currentLine = a:firstLine
+
+    let align = g:NERDDefaultAlign
+    let leftAlignIndx = align == "start" ? 0 : s:LeftMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
+    let rightAlignIndx = s:RightMostIndx(a:forceNested, 0, a:firstLine, a:lastLine)
+    let rightAlignIndx = rightAlignIndx + strlen(s:Left({'space': 1}))
+
     while currentLine <= a:lastLine
 
         " get the next line, check commentability and convert spaces to tabs
@@ -881,8 +888,16 @@ function s:CommentLinesToggle(forceNested, firstLine, lastLine)
                 let theLine = s:SwapOutterMultiPartDelimsForPlaceHolders(theLine)
             endif
 
-            let theLine = s:AddLeftDelim(s:Left({'space': 1}), theLine)
-            let theLine = s:AddRightDelim(s:Right({'space': 1}), theLine)
+            if align == 'left' || align == 'start' || align == 'both'
+                let theLine = s:AddLeftDelimAligned(s:Left({'space': 1}), theLine, leftAlignIndx)
+            else
+                let theLine = s:AddLeftDelim(s:Left({'space': 1}), theLine)
+            endif
+            if align == "both"
+                let theLine = s:AddRightDelimAligned(s:Right({'space': 1}), theLine, rightAlignIndx)
+            else
+                let theLine = s:AddRightDelim(s:Right({'space': 1}), theLine)
+            endif
         endif
 
         " restore leading tabs if appropriate
@@ -929,7 +944,7 @@ function s:CommentRegion(topLine, topCol, bottomLine, bottomCol, forceNested)
         let topOfRange = a:topLine+1
         let bottomOfRange = a:bottomLine-1
         if topOfRange <= bottomOfRange
-            call s:CommentLines(a:forceNested, "none", topOfRange, bottomOfRange)
+            call s:CommentLines(a:forceNested, g:NERDDefaultAlign, topOfRange, bottomOfRange)
         endif
 
         "comment the bottom line
@@ -1021,7 +1036,7 @@ function! NERDComment(isVisual, type) range
         elseif a:isVisual && visualmode() == "v" && (g:NERDCommentWholeLinesInVMode==0 || (g:NERDCommentWholeLinesInVMode==2 && s:HasMultipartDelims()))
             call s:CommentRegion(firstLine, firstCol, lastLine, lastCol, forceNested)
         else
-            call s:CommentLines(forceNested, "none", firstLine, lastLine)
+            call s:CommentLines(forceNested, g:NERDDefaultAlign, firstLine, lastLine)
         endif
 
     elseif a:type == 'alignLeft' || a:type == 'alignBoth'
@@ -1040,7 +1055,7 @@ function! NERDComment(isVisual, type) range
         try
             call s:CommentLinesSexy(firstLine, lastLine)
         catch /NERDCommenter.Delimiters/
-            call s:CommentLines(forceNested, "none", firstLine, lastLine)
+            call s:CommentLines(forceNested, g:NERDDefaultAlign, firstLine, lastLine)
         catch /NERDCommenter.Nesting/
             call s:NerdEcho("Sexy comment aborted. Nested sexy cannot be nested", 0)
         endtry

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -441,7 +441,7 @@ function s:SetUpForNewFiletype(filetype, forceReset)
 endfunction
 
 function s:CreateDelimMapFromCms()
-    if exists('g:NERDDefaultDelims')
+    if &ft == '' && exists('g:NERDDefaultDelims')
         let delims = g:NERDDefaultDelims
         for i in ['left', 'leftAlt', 'right', 'rightAlt']
             if !has_key(delims, i)

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -441,6 +441,15 @@ function s:SetUpForNewFiletype(filetype, forceReset)
 endfunction
 
 function s:CreateDelimMapFromCms()
+    if exists('g:NERDDefaultDelims')
+        let delims = g:NERDDefaultDelims
+        for i in ['left', 'leftAlt', 'right', 'rightAlt']
+            if !has_key(delims, i)
+                let delims[i] = ''
+            endif
+        endfor
+        return delims
+    endif
     return {
         \ 'left': substitute(&commentstring, '\([^ \t]*\)\s*%s.*', '\1', ''),
         \ 'right': substitute(&commentstring, '.*%s\s*\(.*\)', '\1', 'g'),


### PR DESCRIPTION
I add a couple of features that I wanted for commenting that others may find useful:

1. an option to set the default alignment value used by commands which don't have a specific intended alignment.  Using this I can specify how I want NERDCommenterToggle to align my comments.
2. a new alignment value, 'start', which indicates that the comment characters should be inserted at index 0 (column 1) of the line.  As a personal convention, when I'm temporarily commenting code out, I prefer my comment delimiters to be at the very start of the line so that I can quickly pick out what comments are temporary vs permanent.

In addition to updating the help file to document these new features, please also note one gotcha where using the 'start' alignment with g:NERDRemoveExtraSpaces can result in the undesired removal of spaces.  I thought about adding some code to detect and warn the user in this situation, but decided against it at the time.  Its something worth considering when decided whether these changes are worth merging in.
