### PR TITLE
Steven-proofed the documentation, ties to VimDoc

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -83,40 +83,40 @@ See |filetype-plugin-on| for details, but basically, stick this in your vimrc >
 The following key mappings are provided by default (there is also a menu
 with items corresponding to all the mappings below):
 
-[count]<leader>cc |NERDComComment|
+[count]|<Leader>|cc |NERDComComment|
 Comment out the current line or text selected in visual mode.
 
 
-[count]<leader>cn |NERDComNestedComment|
-Same as <leader>cc but forces nesting.
+[count]|<Leader>|cn |NERDComNestedComment|
+Same as |<Leader>|cc but forces nesting.
 
 
-[count]<leader>c<space> |NERDComToggleComment|
+[count]|<Leader>|c<space> |NERDComToggleComment|
 Toggles the comment state of the selected line(s). If the topmost selected
 line is commented, all selected lines are uncommented and vice versa.
 
 
-[count]<leader>cm |NERDComMinimalComment|
+[count]|<Leader>|cm |NERDComMinimalComment|
 Comments the given lines using only one set of multipart delimiters.
 
 
-[count]<leader>ci |NERDComInvertComment|
+[count]|<Leader>|ci |NERDComInvertComment|
 Toggles the comment state of the selected line(s) individually.
 
 
-[count]<leader>cs |NERDComSexyComment|
+[count]|<Leader>|cs |NERDComSexyComment|
 Comments out the selected lines ``sexily''
 
 
-[count]<leader>cy |NERDComYankComment|
-Same as <leader>cc except that the commented line(s) are yanked first.
+[count]|<Leader>|cy |NERDComYankComment|
+Same as |<Leader>|cc except that the commented line(s) are yanked first.
 
 
-<leader>c$ |NERDComEOLComment|
+|<Leader>|c$ |NERDComEOLComment|
 Comments the current line from the cursor to the end of line.
 
 
-<leader>cA |NERDComAppendComment|
+|<Leader>|cA |NERDComAppendComment|
 Adds comment delimiters to the end of line and goes into insert mode between
 them.
 
@@ -126,17 +126,17 @@ Adds comment delimiters at the current cursor position and inserts between.
 Disabled by default.
 
 
-<leader>ca |NERDComAltDelim|
+|<Leader>|ca |NERDComAltDelim|
 Switches to the alternative set of delimiters.
 
 
-[count]<leader>cl
-[count]<leader>cb    |NERDComAlignedComment|
+[count]|<Leader>|cl
+[count]|<Leader>|cb    |NERDComAlignedComment|
 Same as |NERDComComment| except that the delimiters are aligned down the
-left side (<leader>cl) or both sides (<leader>cb).
+left side (|<Leader>|cl) or both sides (|<Leader>|cb).
 
 
-[count]<leader>cu |NERDComUncommentLine|
+[count]|<Leader>|cu |NERDComUncommentLine|
 Uncomments the selected line(s).
 
 ------------------------------------------------------------------------------
@@ -145,7 +145,7 @@ Uncomments the selected line(s).
 ------------------------------------------------------------------------------
 3.2.1 Comment map                                             *NERDComComment*
 
-Default mapping: [count]<leader>cc
+Default mapping: [count]|<Leader>|cc
 Mapped to: <plug>NERDCommenterComment
 Applicable modes: normal visual visual-line visual-block.
 
@@ -161,11 +161,11 @@ lines were selected in visual-line mode.
 ------------------------------------------------------------------------------
 3.2.2 Nested comment map                                *NERDComNestedComment*
 
-Default mapping: [count]<leader>cn
+Default mapping: [count]|<Leader>|cn
 Mapped to: <plug>NERDCommenterNest
 Applicable modes: normal visual visual-line visual-block.
 
-Performs nested commenting.  Works the same as <leader>cc except that if a line
+Performs nested commenting.  Works the same as |<Leader>|cc except that if a line
 is already commented then it will be commented again.
 
 If |'NERDUsePlaceHolders'| is set then the previous comment delimiters will
@@ -182,7 +182,7 @@ Related options:
 ------------------------------------------------------------------------------
 3.2.3 Toggle comment map                                *NERDComToggleComment*
 
-Default mapping: [count]<leader>c<space>
+Default mapping: [count]|<Leader>|c<space>
 Mapped to: <plug>NERDCommenterToggle
 Applicable modes: normal visual-line.
 
@@ -199,14 +199,14 @@ lines were selected in visual-line mode.
 ------------------------------------------------------------------------------
 3.2.4 Minimal comment map                              *NERDComMinimalComment*
 
-Default mapping: [count]<leader>cm
+Default mapping: [count]|<Leader>|cm
 Mapped to: <plug>NERDCommenterMinimal
 Applicable modes: normal visual-line.
 
 Comments the selected lines using one set of multipart delimiters if possible.
 
 For example: if you are programming in c and you select 5 lines and press
-<leader>cm then a '/*' will be placed at the start of the top line and a '*/'
+|<Leader>|cm then a '/*' will be placed at the start of the top line and a '*/'
 will be placed at the end of the last line.
 
 Sets of multipart comment delimiters that are between the top and bottom
@@ -221,7 +221,7 @@ lines were selected in visual-line mode.
 ------------------------------------------------------------------------------
 3.2.5 Invert comment map                                *NERDComInvertComment*
 
-Default mapping: <leader>ci
+Default mapping: |<Leader>|ci
 Mapped to: <plug>NERDCommenterInvert
 Applicable modes: normal visual-line.
 
@@ -238,7 +238,7 @@ lines were selected in visual-line mode.
 ------------------------------------------------------------------------------
 3.2.6 Sexy comment map                                    *NERDComSexyComment*
 
-Default mapping: [count]<leader>cs
+Default mapping: [count]|<Leader>|cs
 Mapped to: <plug>NERDCommenterSexy
 Applicable modes: normal, visual-line.
 
@@ -258,16 +258,16 @@ Related options:
 ------------------------------------------------------------------------------
 3.2.7 Yank comment map                                    *NERDComYankComment*
 
-Default mapping: [count]<leader>cy
+Default mapping: [count]|<Leader>|cy
 Mapped to: <plug>NERDCommenterYank
 Applicable modes: normal visual visual-line visual-block.
 
-Same as <leader>cc except that it yanks the line(s) that are commented first.
+Same as |<Leader>|cc except that it yanks the line(s) that are commented first.
 
 ------------------------------------------------------------------------------
 3.2.8 Comment to EOL map                                   *NERDComEOLComment*
 
-Default mapping: <leader>c$
+Default mapping: |<Leader>|c$
 Mapped to: <plug>NERDCommenterToEOL
 Applicable modes: normal.
 
@@ -277,7 +277,7 @@ the line.
 ------------------------------------------------------------------------------
 3.2.9 Append com to line map                            *NERDComAppendComment*
 
-Default mapping: <leader>cA
+Default mapping: |<Leader>|cA
 Mapped to: <plug>NERDCommenterAppend
 Applicable modes: normal.
 
@@ -303,12 +303,12 @@ to your vimrc.
 ------------------------------------------------------------------------------
 3.2.11 Use alternate delims map                              *NERDComAltDelim*
 
-Default mapping: <leader>ca
+Default mapping: |<Leader>|ca
 Mapped to: <plug>NERDCommenterAltDelims
 Applicable modes: normal.
 
 Changes to the alternative commenting style if one is available. For example,
-if the user is editing a c++ file using // comments and they hit <leader>ca
+if the user is editing a c++ file using // comments and they hit |<Leader>|ca
 then they will be switched over to /**/ comments.
 
 See also |NERDComDefaultDelims|
@@ -316,12 +316,12 @@ See also |NERDComDefaultDelims|
 ------------------------------------------------------------------------------
 3.2.12 Comment aligned maps                            *NERDComAlignedComment*
 
-Default mappings: [count]<leader>cl   [count]<leader>cb
+Default mappings: [count]|<Leader>|cl   [count]|<Leader>|cb
 Mapped to: <plug>NERDCommenterAlignLeft
            <plug>NERDCommenterAlignBoth
 Applicable modes: normal visual-line.
 
-Same as <leader>cc except that the comment delimiters are aligned on the left
+Same as |<Leader>|cc except that the comment delimiters are aligned on the left
 side or both sides respectively. These comments are always nested if the
 line(s) are already commented.
 
@@ -331,7 +331,7 @@ lines were selected in visual-line mode.
 ------------------------------------------------------------------------------
 3.2.13 Uncomment line map                               *NERDComUncommentLine*
 
-Default mapping: [count]<leader>cu
+Default mapping: [count]|<Leader>|cu
 Mapped to: <plug>NERDCommenterUncomment
 Applicable modes: normal visual visual-line visual-block.
 
@@ -589,7 +589,7 @@ this option tells the script whether to look for, and remove, comment
 delimiters of the alternative style.
 
 For example, if you are editing a c++ file using // style comments and you go
-<leader>cu on this line: >
+|<Leader>|cu on this line: >
     /* This is a c++ comment baby! */
 <
 It will not be uncommented if the NERDRemoveAltComs is set to 0.
@@ -639,7 +639,7 @@ To set these options use lines like: >
 Following the above example, if we have line of c code: >
     /* int horse */
 <
-and we comment it with <leader>cn it will be changed to: >
+and we comment it with |<Leader>|cn it will be changed to: >
     /*FOO int horse BAR*/
 <
 When we uncomment this line it will go back to what it was.
@@ -704,7 +704,7 @@ Values: 0 or 1.
 Default 1.
 
 When this option is set to 1, comments are nested automatically. That is, if
-you hit <leader>cc on a line that is already commented it will be commented
+you hit |<Leader>|cc on a line that is already commented it will be commented
 again.
 
 ------------------------------------------------------------------------------
@@ -805,7 +805,7 @@ The latest dev versions are on github
       runtime for vim > 7.0 unless the script stores an alternate set of
       delimiters
     - make the script complain if the user doesnt have filetype plugins enabled
-    - use <leader> instead of comma to start the default mappings
+    - use |<Leader>| instead of comma to start the default mappings
     - fix a couple of bugs with sexy comments - thanks to Tim Smart
     - lots of refactoring
 


### PR DESCRIPTION
Per [my issue](https://github.com/scrooloose/nerdcommenter/issues/29), ties into the VimDoc for `<Leader>` and `mapleader`, which are not `CTRL-]`-able from the extant `<leader>` tags. 
