### PR TITLE
End-of-line comments within a multipart block get uncommented when they shouldn't

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1417,14 +1417,14 @@ function s:UncommentLineNormal(line)
         "remove the outter most left comment delim
         if indxLeft != -1 && (indxLeft < indxLeftAlt || indxLeftAlt == -1)
             let line = s:RemoveDelimiters(s:Left(), '', line)
-        elseif indxLeftAlt != -1
+        elseif indxLeftAlt != -1 && g:NERDRemoveAltComs
             let line = s:RemoveDelimiters(s:Left({'alt': 1}), '', line)
         endif
 
         "remove the outter most right comment delim
         if indxRight != -1 && (indxRight < indxRightAlt || indxRightAlt == -1)
             let line = s:RemoveDelimiters('', s:Right(), line)
-        elseif indxRightAlt != -1
+        elseif indxRightAlt != -1 && g:NERDRemoveAltComs
             let line = s:RemoveDelimiters('', s:Right({'alt': 1}), line)
         endif
     endif


### PR DESCRIPTION
A user on [this Convore discussion](https://convore.com/vim/good-comenting-plugin-for-web-developers/) pointed out that uncommenting this block of code didn't behave as desired, resulting in the `//`-style comment within the multipart block also being uncommented and leaving broken code:

``` javascript
/*function clear_commercial_message() {
    $message.empty().html(app.templates.message);
    setTimeout( 'update_commercial_message()', 5000 );  // Clear commercial message after 10 secs.
}*/
```

This happens regardless of the value of `NERDRemoveAltComs`, which I believe is incorrect behavior. It might be nice to have a fancier DWIM solution since `NERDRemoveAltComs` is true by default, but this patch is simple and "correct," I believe: when I set the delimiters to `/*`-style and `let`NERDRemoveAltComs=0`, uncommenting blocks like this works as expected.
