### PR TITLE
Add syntax for comments in Ruby

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -305,6 +305,7 @@ let s:delimiterMap = {
     \ 'rgb': { 'left': '!' },
     \ 'rib': { 'left': '#' },
     \ 'robots': { 'left': '#' },
+    \ 'ruby': { 'left': '#' },
     \ 'sa': { 'left': '--' },
     \ 'samba': { 'left': ';', 'leftAlt': '#' },
     \ 'sass': { 'left': '//', 'leftAlt': '/*' },


### PR DESCRIPTION
When using this vim plugin my Ruby comments do not appear properly.  I've added this comment definition so that ruby code can be commented using the proper hash comment syntax.
