### PR TITLE
Create xmaps instead of vmaps

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -2753,7 +2753,7 @@ function! s:CreateMaps(target, combo)
     endif
 
     if !hasmapto(a:target, 'v')
-        exec 'vmap ' . a:combo . ' ' . a:target
+        exec 'xmap ' . a:combo . ' ' . a:target
     endif
 endfunction
 


### PR DESCRIPTION
A `vmap` affects select mode, which tends to be annoying and/or confusing when the left hand side of the map consists of printable characters. It seems `hasmapto()` can't check for a visual only map, but that's okay as the `'v'` argument works fine and a user might for some reason desire the maps be available in select mode. I could just create `xmap`s in my vimrc but figured I'd submit a pull request anyway. Thanks.
