### PR TITLE
add support for scss leftalt comment

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -198,6 +198,7 @@ let s:delimiterMap = {
     \ 'ishd': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'iss': { 'left': ';' },
     \ 'ist': { 'left': '%' },
+    \ 'jade': { 'left': '//-', 'leftAlt': '//' },
     \ 'java': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'javacc': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'javascript': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },


### PR DESCRIPTION
scss uses '//' as an alternative (scss only) commenting pattern, which are stripped from the scss file at css generation time

cf. http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#comments
