### PR TITLE
Add maps (keyboard shortcuts) to GUI menu items.

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -162,7 +162,7 @@ lines were selected in visual-line mode.
 3.2.2 Nested comment map                                *NERDComNestedComment*
 
 Default mapping: [count]|<Leader>|cn
-Mapped to: <plug>NERDCommenterNest
+Mapped to: <plug>NERDCommenterNested
 Applicable modes: normal visual visual-line visual-block.
 
 Performs nested commenting.  Works the same as |<Leader>|cc except that if a line
@@ -288,7 +288,7 @@ to insert mode between the new delimiters.
 3.2.10 Insert comment map                               *NERDComInsertComment*
 
 Default mapping: disabled by default.
-Map it to: <plug>NERDCommenterInInsert
+Map it to: <plug>NERDCommenterInsert
 Applicable modes: insert.
 
 Adds comment delimiters at the current cursor position and inserts


### PR DESCRIPTION
I am new to Git and GitHub.  This is my first pull request, so forgive me if I make a beginner's mistake.

I am not new to vim scripting.

I like to use GUI menus for features I use rarely and to teach me the key strokes to use for features I use frequently.  These changes add the key mappings to the GUI menus in NERDCommenter.  This will not help me when I use my usual computer, since it is a Mac, but it works on my Windows laptop and should work in the gnome (and maybe other Linux) GUI.  (Maybe it is time to update Vim.app on my Mac.)

I combine the s:CreateMaps() and s:CreateMenuItems() functions into one Chimera of a function that accomplishes both tasks.  I figure this should appeal to the "bastard son of Megatron and Godzilla."  In addition to raw monster appeal, this guarantees that the menu item uses the right key mapping.

I noticed that \c$ and \cA cause a beep when invoked in Visual mode, and that the corresponding menu items were defined only in Normal mode.  In my version, these maps are only defined for Normal mode.

I also noticed that \cu sometimes moves the cursor if the line is not commented out.  I did not investigate.
