### PR TITLE
Make mappings repeatable with . through repeat.vim

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -139,6 +139,10 @@ left side (|<Leader>|cl) or both sides (|<Leader>|cb).
 [count]|<Leader>|cu |NERDComUncommentLine|
 Uncomments the selected line(s).
 
+
+With the optional repeat.vim plugin (vimscript #2136), the mappings can also
+be repeated via |.|
+
 ------------------------------------------------------------------------------
 3.2 Functionality details                        *NERDComFunctionalityDetails*
 

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1128,6 +1128,8 @@ function! NERDComment(mode, type) range
     endif
 
     let &ignorecase = oldIgnoreCase
+
+    silent! call repeat#set("\<Plug>NERDCommenter". a:type)
 endfunction
 
 " Function: s:PlaceDelimitersAndInsBetween() function {{{2


### PR DESCRIPTION
Use of repeat.vim is purely optional, but very beneficial for typical commenting uses.

This has already been requested by #31 (a year ago), but you failed to accept that patch so far, maybe because it also includes yank enhancements in the same pull request. This is a _minimal_ patch to support repeat.vim. There are many fans of this plugin; I personally find this crucial. Please accept this.
