### PR TITLE
I did a tiny change to add comment support for Octave filetype

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -267,6 +267,7 @@ let s:delimiterMap = {
     \ 'objj': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'ocaml': { 'left': '(*', 'right': '*)' },
     \ 'occam': { 'left': '--' },
+    \ 'octave': { 'left': '%', 'leftAlt': '#' },
     \ 'omlet': { 'left': '(*', 'right': '*)' },
     \ 'omnimark': { 'left': ';' },
     \ 'ooc': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },


### PR DESCRIPTION
Octave, http://www.octave.org, is a opensource Matlab clone. It has two styles of comment: '%' and '#'. Therefore 'set ft=matlab' doesn't always work for Octave's m-file.
