### PR TITLE
change Haskell line comment to '-- '

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -180,7 +180,7 @@ let s:delimiterMap = {
     \ 'groovy': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'gsp': { 'left': '<%--', 'right': '--%>', 'leftAlt': '<!--','rightAlt': '-->'},
     \ 'gtkrc': { 'left': '#' },
-    \ 'haskell': { 'left': '{-','right': '-}', 'leftAlt': '-- ' },
+    \ 'haskell': { 'left': '-- ', 'leftAlt': '{-', 'rightAlt': '-}' },
     \ 'hb': { 'left': '#' },
     \ 'h': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'haml': { 'left': '-#', 'leftAlt': '/' },


### PR DESCRIPTION
'--' isn't always a valid line comment starter in Haskell.
For example: '-->' would be a perfectly fine operator name.

Hence, using '-- ' for line comments is common practice.