### PR TITLE
Update plugin/NERD_commenter.vim

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -114,6 +114,7 @@ let s:delimiterMap = {
     \ 'cmake': { 'left': '#' },
     \ 'coffee': { 'left': '#' },
     \ 'conkyrc': { 'left': '#' },
+    \ 'context': { 'left': '%', 'leftAlt': '--' },
     \ 'cpp': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'crontab': { 'left': '#' },
     \ 'cs': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },


### PR DESCRIPTION
Add comment delimiters for ConTeXt files: '%' for normal comments, '--' for inside LuaTeX blocks.
