### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Comment out the current line or text selected in visual mode.
 Same as \<leader\>cc but forces nesting. 
 
 
-**[count]\<leader\>c<space> |NERDComToggleComment|**  
+**[count]\<leader\>c\<space\> |NERDComToggleComment|**  
 Toggles the comment state of the selected line(s). If the topmost selected 
 line is commented, all selected lines are uncommented and vice versa. 
 


### PR DESCRIPTION
This is funny and caused me a bit of a headache the other day when I was checking out NERDCommenter for the first time.

I was incorrectly trying to toggle comments using just `<Leader>c` when I should have been using `<Leader>c<space>`.  Why was I doing that, you ask?  When github was parsing the repo's README.md file for display, it was incorrectly passing the `<space>` part through as an html tag so it wasn't showing up at all.  Thus, the docs on the redo homepage read `<Leader>c` for the `NERDComToggleComment` command.  Plain old `<Leader>c` was being interpreted in vim as the change lines command, so the lines I was selecting were being deleted.

At first, I was like "Man...this plugin doesn't work!"  Then, the next day, I gave it another try and noticed the error after reading the vim docs using `:help nerdcommenter`.
