### PR TITLE
Added support for fortran and yaml filetypes

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -157,6 +157,7 @@ let s:delimiterMap = {
     \ 'fgl': { 'left': '#' },
     \ 'focexec': { 'left': '-*' },
     \ 'form': { 'left': '*' },
+    \ 'fortran': { 'left': '!' },
     \ 'foxpro': { 'left': '*' },
     \ 'fsharp': { 'left': '(*', 'right': '*)', 'leftAlt': '//' },
     \ 'fstab': { 'left': '#' },
@@ -403,6 +404,7 @@ let s:delimiterMap = {
     \ 'xmath': { 'left': '#' },
     \ 'xpm2': { 'left': '!' },
     \ 'xquery': { 'left': '(:', 'right': ':)' },
+    \ 'yaml': { 'left': '#' },
     \ 'z8a': { 'left': ';' }
     \ }
 


### PR DESCRIPTION
Not strictly necessary since the &commentstring option gives valid comment characters (but then, that seems to be true of most other filetypes supported).

(Thanks for an awesome plugin, by the way).