### PR TITLE
Update Python comment style

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -303,7 +303,7 @@ let s:delimiterMap = {
     \ 'psf': { 'left': '#' },
     \ 'ptcap': { 'left': '#' },
     \ 'puppet': { 'left': '#' },
-    \ 'python': { 'left': '#' },
+    \ 'python': { 'left': '# ' },
     \ 'radiance': { 'left': '#' },
     \ 'ratpoison': { 'left': '#' },
     \ 'r': { 'left': '#' },


### PR DESCRIPTION
The [PEP8](http://www.python.org/dev/peps/pep-0008/#inline-comments)\(Style Guide for Python Code\) said:

> An inline comment is a comment on the same line as a statement. 
> Inline comments should be separated by at least two spaces from the statement.
>  **They should start with a # and a single space**.