### PR TITLE
Implement functionality to chose the alternative comment style

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -714,11 +714,11 @@ again.
 
 If you want the NERD commenter to use the alternative delimiters for a
 specific filetype by default then put a line of this form into your vimrc: >
-    let NERD_<filetype>_alt_style=1
+    let g:NERD_<filetype>_alt_style=1
 <
 Example: java uses // style comments by default, but you want it to default to
 /* */ style comments instead. You would put this line in your vimrc: >
-    let NERD_java_alt_style=1
+    let g:NERD_java_alt_style=1
 <
 
 See |NERDComAltDelim| for switching commenting styles at runtime.

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -462,6 +462,10 @@ function s:SetUpForNewFiletype(filetype, forceReset)
                 let b:NERDCommenterDelims[i] = ''
             endif
         endfor
+        " if g:NERD_<filetype>_alt_style is defined, use the alternate style
+        if exists('g:NERD_'.ft.'_alt_style') && eval('g:NERD_'.ft.'_alt_style')
+            call s:SwitchToAlternativeDelimiters(0)
+        endif
     else
         let b:NERDCommenterDelims = s:CreateDelimMapFromCms()
     endif
@@ -2379,7 +2383,7 @@ endfunction
 function s:Left(...)
     let params = a:0 ? a:1 : {}
 
-    let delim = has_key(params, 'alt') ? b:NERDCommenterDelims['leftAlt'] : b:NERDCommenterDelims['left'] 
+    let delim = has_key(params, 'alt') ? b:NERDCommenterDelims['leftAlt'] : b:NERDCommenterDelims['left']
 
     if delim == ''
         return ''
@@ -2558,7 +2562,7 @@ endfunction
 function s:Right(...)
     let params = a:0 ? a:1 : {}
 
-    let delim = has_key(params, 'alt') ? b:NERDCommenterDelims['rightAlt'] : b:NERDCommenterDelims['right'] 
+    let delim = has_key(params, 'alt') ? b:NERDCommenterDelims['rightAlt'] : b:NERDCommenterDelims['right']
 
     if delim == ''
         return ''

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -463,8 +463,10 @@ function s:SetUpForNewFiletype(filetype, forceReset)
             endif
         endfor
         " if g:NERD_<filetype>_alt_style is defined, use the alternate style
-        if exists('g:NERD_'.ft.'_alt_style') && eval('g:NERD_'.ft.'_alt_style')
+        let b:NERDCommenterFirstInit = getbufvar(1,"NERDCommenterFirstInit",0)
+        if exists('g:NERD_'.ft.'_alt_style') && eval('g:NERD_'.ft.'_alt_style') && !b:NERDCommenterFirstInit
             call s:SwitchToAlternativeDelimiters(0)
+            let b:NERDCommenterFirstInit = 1
         endif
     else
         let b:NERDCommenterDelims = s:CreateDelimMapFromCms()


### PR DESCRIPTION
This somewhat fixes Issue #145.

I have no experience in VimL whatsoever, but this seems to be the proper way to respect the NERD_\<filetype\>_alt_style feature. 

If you agree that this is a valid fix, I'd have no problem creating another commit that updates the documentation.