### PR TITLE
Add ability to comment starting at first column instead of first non whitespace character

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -431,6 +431,9 @@ then the script would do a sexy comment on the last visual selection.
                                       around delimiters when commenting, and
                                       whether to remove them when
                                       uncommenting.
+|'NERDLeftStartFirstColumn'|          Comment from the first column of the line
+                                      instead of from the first non whitespace
+                                      character.
 |'NERDCompactSexyComs'|               Specifies whether to use the compact
                                       style sexy comments.
 

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -61,6 +61,7 @@ call s:InitVariable("g:NERDRemoveAltComs", 1)
 call s:InitVariable("g:NERDRemoveExtraSpaces", 0)
 call s:InitVariable("g:NERDRPlace", "<]")
 call s:InitVariable("g:NERDSpaceDelims", 0)
+call s:InitVariable("g:NERDLeftStartFirstColumn", 0)
 
 let s:NERDFileNameEscape="[]#*$%'\" ?`!&();<>\\"
 
@@ -1509,7 +1510,8 @@ endfunction
 " Function: s:AddLeftDelim(delim, theLine) {{{2
 " Args:
 function s:AddLeftDelim(delim, theLine)
-    return substitute(a:theLine, '^\([ \t]*\)', '\1' . a:delim, '')
+    let pattern = g:NERDLeftStartFirstColumn ? '^' : '^\([ \t]*\)'
+    return substitute(a:theLine, pattern, '\1' . a:delim, '')
 endfunction
 
 " Function: s:AddLeftDelimAligned(delim, theLine) {{{2


### PR DESCRIPTION
I generally prefer my block comments to all start in the first column rather than before the actual content. This adds an option to support that. Also, my vim script is minimal so I have only the vaguest notion if this is correct. Thanks for the plugin!