### PR TITLE
Fix delimiter for stp filetype (SystemTap)

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -358,7 +358,7 @@ let s:delimiterMap = {
     \ 'sqr': { 'left': '!' },
     \ 'squid': { 'left': '#' },
     \ 'st': { 'left': '"' },
-    \ 'stp': { 'left': '--' },
+    \ 'stp': { 'left': '/*','right': '*/', 'leftAlt': '//' },
     \ 'supercollider': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'systemverilog': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'tads': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },


### PR DESCRIPTION
I was working on SystemTap scripts and found out that the delimiter for stp filetype is incorrect. 

According to the language reference [1]:
> Three forms of comments are supported, as follows.
> \# ... shell style, to the end of line
> // ... C++ style, to the end of line
> /* ... C style ... */

I changed the delimiter to the "C style" in the nerd commenter.

The reason is a stp script can have embedded C code [2], which makes the "shell style" inappropriate.

Ref:
[1] https://sourceware.org/systemtap/langref/Language_elements.html#SECTION00064000000000000000
[2] https://sourceware.org/systemtap/langref/Components_SystemTap_script.html#SECTION00045000000000000000