### PR TITLE
Use pep8 compatible comments for python

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -303,7 +303,7 @@ let s:delimiterMap = {
     \ 'psf': { 'left': '#' },
     \ 'ptcap': { 'left': '#' },
     \ 'puppet': { 'left': '#' },
-    \ 'python': { 'left': '#' },
+    \ 'python': { 'left': '# ' },
     \ 'radiance': { 'left': '#' },
     \ 'ratpoison': { 'left': '#' },
     \ 'r': { 'left': '#' },


### PR DESCRIPTION
Python uses a lint program called pep8 that wants a space after the '#'.  Provide that by default.