### PR TITLE
Correct bib comment delimiter.

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -94,7 +94,7 @@ let s:delimiterMap = {
     \ 'basic': { 'left': "'", 'leftAlt': 'REM ' },
     \ 'bbx': { 'left': '%' },
     \ 'bc': { 'left': '#' },
-    \ 'bib': { 'left': '%' },
+    \ 'bib': { 'left': '//' },
     \ 'bindzone': { 'left': ';' },
     \ 'bst': { 'left': '%' },
     \ 'btm': { 'left': '::' },


### PR DESCRIPTION
'%' is not a comment delimiter for bib files. '//' works fine.