### PR TITLE
Add support for sshdconfig files

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -357,6 +357,7 @@ let s:delimiterMap = {
     \ 'sqlj': { 'left': '-- ' },
     \ 'sqr': { 'left': '!' },
     \ 'squid': { 'left': '#' },
+    \ 'sshdconfig': { 'left': '#' },
     \ 'st': { 'left': '"' },
     \ 'stp': { 'left': '--' },
     \ 'supercollider': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },


### PR DESCRIPTION
The sshdconfig filetype provider does not set `commentstring`, so
support must be explicitly defined.