### PR TITLE
Add config to allow commenting empty lines (useful for Golang's godoc)

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -51,6 +51,7 @@ let s:lenSpaceStr = strlen(s:spaceStr)
 call s:InitVariable("g:NERDAllowAnyVisualDelims", 1)
 call s:InitVariable("g:NERDBlockComIgnoreEmpty", 0)
 call s:InitVariable("g:NERDCommentWholeLinesInVMode", 0)
+call s:InitVariable("g:NERDCommentEmptyLines", 0)
 call s:InitVariable("g:NERDCompactSexyComs", 0)
 call s:InitVariable("g:NERDCreateDefaultMappings", 1)
 call s:InitVariable("g:NERDDefaultNesting", 1)
@@ -1571,8 +1572,9 @@ endfunction
 function s:CanCommentLine(forceNested, lineNum)
     let theLine = getline(a:lineNum)
 
-    " make sure we don't comment lines that are just spaces or tabs or empty.
-    if theLine =~ "^[ \t]*$"
+    " make sure we don't comment lines that are just spaces or tabs or empty,
+    " unless configured otherwise
+    if g:NERDCommentEmptyLines == 0 && theLine =~ "^[ \t]*$"
         return 0
     endif
 


### PR DESCRIPTION
The motivation here is how Golang's godoc works:

> godoc processes Go source files to extract documentation about the contents of the package. Comments that appear before top-level declarations, **with no intervening newlines,** are extracted along with the declaration to serve as explanatory text for the item.
>
> <cite>https://golang.org/doc/effective_go.html#commentary</cite>
> <cite>http://godoc.org/golang.org/x/tools/cmd/godoc</cite>

E.g. before this PR

```go
// This whole block is commented
// in two separate blocks,

// because there's an empty line
// between the first and second block,
// and if you select until the empty line below,
// it's not commented either

func doSome() {
}
```

For godoc to capture the whole comment block, and associate it with the following function in the generated documentation, we need the whole block to be commented until the last line before the function declaration.

E.g. after this PR, with NERDCommentEmptyLines=1

```go
// This whole block is commented
// as one single comment block
//
// despite of empty lines between blocks,
// and if you select until the empty line below,
// it'll be commented as well
//
func doSome() {
}
```

I kept the original behavior by setting NERDCommentEmptyLines=0 by default, so it can be overridden in vimrc with:

```vim
au FileType go let NERDCommentEmptyLines=1
```