### PR TITLE
Changed python delimiter to matchpep8

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -303,7 +303,7 @@ let s:delimiterMap = {
     \ 'psf': { 'left': '#' },
     \ 'ptcap': { 'left': '#' },
     \ 'puppet': { 'left': '#' },
-    \ 'python': { 'left': '#' },
+    \ 'python': { 'left': '# ' },
     \ 'radiance': { 'left': '#' },
     \ 'ratpoison': { 'left': '#' },
     \ 'r': { 'left': '#' },


### PR DESCRIPTION
per https://www.python.org/dev/peps/pep-0008/#id22 comments should be a # followed by a space.