### PR TITLE
Fix Markdown comments

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -244,7 +244,7 @@ let s:delimiterMap = {
     \ 'mel': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'mib': { 'left': '--' },
     \ 'mirah': {'left': '#'},
-    \ 'mkd': { 'left': '>' },
+    \ 'mkd': { 'left': '<!---', 'right': '-->' },
     \ 'mma': { 'left': '(*', 'right': '*)' },
     \ 'model': { 'left': '$', 'right': '$' },
     \ 'moduala.': { 'left': '(*', 'right': '*)' },


### PR DESCRIPTION
The current Markdown comment, `>`, does not work in the pandoc implementation of Markdown. I am not aware of any implementation of Markdown that uses the `>` character as a comment symbol, especially since it is used by some implementations for quotation blocks, which is a completely different function (at least, I couldn't find any). Thus, the proposed implementation would work in at least some implementations.