### PR TITLE
Add support for terraform files

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -366,6 +366,7 @@ let s:delimiterMap = {
     \ 'tak': { 'left': '$' },
     \ 'tasm': { 'left': ';' },
     \ 'tcl': { 'left': '#' },
+    \ 'terraform': { 'left': '#', 'leftAlt': '/*', 'rightAlt': '*/'  },
     \ 'texinfo': { 'left': "@c " },
     \ 'texmf': { 'left': '%' },
     \ 'tf': { 'left': ';' },


### PR DESCRIPTION
Terraform files are used to define different resources. Single line comments use a `#` and multi-line comments use `/* ... */`. For more information, see https://terraform.io/docs/configuration/syntax.html.

For a terraform syntax plugin, see https://github.com/markcornick/vim-terraform.