### PR TITLE
remove '[>' '<]' in uncommented lines

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1423,12 +1423,6 @@ endfunction
 function s:UncommentLineNormal(line)
     let line = a:line
 
-    "get the positions of all delim types on the line
-    let indxLeft = s:FindDelimiterIndex(s:Left(), line)
-    let indxLeftAlt = s:FindDelimiterIndex(s:Left({'alt': 1}), line)
-    let indxRight = s:FindDelimiterIndex(s:Right(), line)
-    let indxRightAlt = s:FindDelimiterIndex(s:Right({'alt': 1}), line)
-
     "get the comment status on the line so we know how it is commented
     let lineCommentStatus =  s:IsCommentedOuttermost(s:Left(), s:Right(), s:Left({'alt': 1}), s:Right({'alt': 1}), line)
 
@@ -1443,6 +1437,12 @@ function s:UncommentLineNormal(line)
     "it is not properly commented with any delims so we check if it has
     "any random left or right delims on it and remove the outtermost ones
     else
+        "get the positions of all delim types on the line
+        let indxLeft = s:FindDelimiterIndex(s:Left(), line)
+        let indxLeftAlt = s:FindDelimiterIndex(s:Left({'alt': 1}), line)
+        let indxRight = s:FindDelimiterIndex(s:Right(), line)
+        let indxRightAlt = s:FindDelimiterIndex(s:Right({'alt': 1}), line)
+
         "remove the outter most left comment delim
         if indxLeft != -1 && (indxLeft < indxLeftAlt || indxLeftAlt == -1)
             let line = s:RemoveDelimiters(s:Left(), '', line)
@@ -1459,7 +1459,10 @@ function s:UncommentLineNormal(line)
     endif
 
 
+    let indxLeft = s:FindDelimiterIndex(s:Left(), line)
+    let indxLeftAlt = s:FindDelimiterIndex(s:Left({'alt': 1}), line)
     let indxLeftPlace = s:FindDelimiterIndex(g:NERDLPlace, line)
+
     let indxRightPlace = s:FindDelimiterIndex(g:NERDRPlace, line)
 
     let right = s:Right()


### PR DESCRIPTION
Fix issue [#170](https://github.com/scrooloose/nerdcommenter/issues/170)

The bug was first introduced in commit [f98f73221cfc4068757d51630eb6471e9bbc0765](https://github.com/scrooloose/nerdcommenter/commit/f98f73221cfc4068757d51630eb6471e9bbc0765#diff-dbe18dafa1a26d07f006230ba76ab184L1400).

Since $line may be updated in case 1 or case 2 (see the code), hence $indxLeft, $indxLeftAlt, $indxRight, $indxRightAlt must be updated after the if block.
