### PR TITLE
Add comment syntax for SILE

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -332,6 +332,7 @@ let s:delimiterMap = {
     \ 'sgmllnx': { 'left': '<!--', 'right': '-->' },
     \ 'sh': { 'left': '#' },
     \ 'sicad': { 'left': '*' },
+    \ 'sile': { 'left': '%' },
     \ 'simula': { 'left': '%', 'leftAlt': '--' },
     \ 'sinda': { 'left': '$' },
     \ 'skill': { 'left': ';' },


### PR DESCRIPTION
Sile is a typesetter somewhat similar to LaTeX that uses two different
possible input formats. Input can be XML which is already covered or
there is a TeX like input format. The normal file extension for the
latter is .sil.