### PR TITLE
updated ruby comment to fit with ruby style guide

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -316,7 +316,7 @@ let s:delimiterMap = {
     \ 'rib': { 'left': '#' },
     \ 'robots': { 'left': '#' },
     \ 'rspec': { 'left': '#' },
-    \ 'ruby': { 'left': '#' },
+    \ 'ruby': { 'left': '# ', 'leftAlt': '#' },
     \ 'sa': { 'left': '--' },
     \ 'samba': { 'left': ';', 'leftAlt': '#' },
     \ 'sass': { 'left': '//', 'leftAlt': '/*' },


### PR DESCRIPTION
[Ruby Style Guide](https://github.com/bbatsov/ruby-style-guide#hash-space) prefers a `#` with a space instead of a plain `#`.

