### PR TITLE
updated scss comment style to correspond to the style guide

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -326,7 +326,7 @@ let s:delimiterMap = {
     \ 'scheme': { 'left': ';', 'leftAlt': '#|', 'rightAlt': '|#' },
     \ 'scilab': { 'left': '//' },
     \ 'scsh': { 'left': ';' },
-    \ 'scss': { 'left': '/*', 'right': '*/', 'leftAlt': '//' },
+    \ 'scss': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/'},
     \ 'sed': { 'left': '#' },
     \ 'sgmldecl': { 'left': '--', 'right': '--' },
     \ 'sgmllnx': { 'left': '<!--', 'right': '-->' },


### PR DESCRIPTION
scss [seems to prefer](https://github.com/brigade/scss-lint/blob/5f757444622fbb76bcebaaa7db4fbdfca659ae3f/README.md#what-gets-linted) `//` over `/*` style comments.