### PR TITLE
Reapply PR #183 for Python comments, PR #100 undid this

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -320,7 +320,7 @@ let s:delimiterMap = {
     \ 'psf': { 'left': '#' },
     \ 'ptcap': { 'left': '#' },
     \ 'puppet': { 'left': '#' },
-    \ 'python': { 'left': '#' },
+    \ 'python': { 'left': '# ', 'leftAlt': '#' },
     \ 'racket': { 'left': ';' },
     \ 'radiance': { 'left': '#' },
     \ 'ratpoison': { 'left': '#' },


### PR DESCRIPTION
Pull request #100 for Racket undid the Python change, see the difference at https://github.com/scrooloose/nerdcommenter/commit/8d3dcc26a6c6b7cb98669bb6a6f9bdbc23f9e770.

This reapplies the patch from #183.

CC @alerque 