### PR TITLE
Add ruby multiline comment tags

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -316,7 +316,7 @@ let s:delimiterMap = {
     \ 'rib': { 'left': '#' },
     \ 'robots': { 'left': '#' },
     \ 'rspec': { 'left': '#' },
-    \ 'ruby': { 'left': '#' },
+    \ 'ruby': { 'left': '#', 'leftAlt': '=begin', 'rightAlt': '=end' },
     \ 'sa': { 'left': '--' },
     \ 'samba': { 'left': ';', 'leftAlt': '#' },
     \ 'sass': { 'left': '//', 'leftAlt': '/*' },


### PR DESCRIPTION
(Found in outdated fork on Github network graph.)

Note this will mean the Ruby default comment doesn't have a space after it any more, those who prefer that style should set `let g:NERDSpaceDelims = 1`. Also see the discussion in #202 on how to make a better fix for this recurring issue.