### PR TITLE
Use getbufvar in an old-fashioned way for backward compatibility

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -515,7 +515,7 @@ function s:SetUpForNewFiletype(filetype, forceReset)
             endif
         endfor
         " if g:NERD_<filetype>_alt_style is defined, use the alternate style
-        let b:NERDCommenterFirstInit = getbufvar(1,"NERDCommenterFirstInit",0)
+        let b:NERDCommenterFirstInit = getbufvar(1,"NERDCommenterFirstInit")
         if exists('g:NERDAltDelims_'.ft) && eval('g:NERDAltDelims_'.ft) && !b:NERDCommenterFirstInit
             call s:SwitchToAlternativeDelimiters(0)
             let b:NERDCommenterFirstInit = 1


### PR DESCRIPTION
Vim included in OS X 10.11.5 has a trouble with the latest version of NERD Commenter:

    E118: Too many arguments for function: getbufvar
    E15: Invalid expression: getbufvar(1,"NERDCommenterFirstInit", 0)

`getbufvar` accepts only two arguments in Vim 7.3 (at least the one included in OS X 10.11.5), and returns an empty string when the buffer or variable does not exist: `getbufvar({buffer}, {variable})`.

Vim 7.4 has extended the built-in function so that it additionally accepts an optional argument which determines the default return value: `getbufvar({buffer}, {variable}, [, {default}])`. When the third argument is not given and the buffer or variable does not exists, `getbufvar` returns an empty string as before.

`getbufvar({buffer}, {variable})` works in both Vim 7.3 and 7.4, and is practically equivalent to `getbufvar({buffer}, {variable}, 0) `because an empty string is coerced to 0 if necessary.