### PR TITLE
Add hook functions for NERDComment and SwitchToAlternativeDelimiters

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -28,8 +28,9 @@ CONTENTS                                               *NERDCommenterContents*
             3.2.11 Use alternate delims map...|NERDComAltDelim|
             3.2.12 Comment aligned maps.......|NERDComAlignedComment|
             3.2.13 Uncomment line map.........|NERDComUncommentLine|
-        3.4 Sexy Comments.....................|NERDComSexyComments|
-        3.5 The NERDComment function..........|NERDComNERDComment|
+        3.3 Sexy Comments.....................|NERDComSexyComments|
+        3.4 The NERDComment function..........|NERDComNERDComment|
+        3.5 The Hooks.........................|NERDComHooks|
     4.Options.................................|NERDComOptions|
         4.1 Options summary...................|NERDComOptionsSummary|
         4.2 Options details...................|NERDComOptionsDetails|
@@ -391,6 +392,35 @@ For example, if you typed >
 <
 then the script would do a sexy comment on the last visual selection.
 
+------------------------------------------------------------------------------
+3.5 The hooks                                                   *NERDComHooks*
+|fu! NERDCommenter_before()|  Before NERDComment/SwitchToAlternativeDelimiters
+|fu! NERDCommenter_after()|    After NERDComment/SwitchToAlternativeDelimiters
+
+For example, in order to handle different language blocks embedded in the same
+file such as |vim-vue|, you can change the filetype, comment something and
+change the filetype back: >
+    let g:ft = ''
+    fu! NERDCommenter_before()
+        if &ft == 'vue'
+            let g:ft = 'vue'
+            let stack = synstack(line('.'), col('.'))
+            if len(stack) > 0
+                let syn = synIDattr((stack)[0], 'name')
+                if len(syn) > 0
+                    let syn = tolower(syn)
+                    exe 'setf '.syn
+                endif
+            endif
+        endif
+    endfu
+    fu! NERDCommenter_after()
+        if g:ft == 'vue'
+            setf vue
+            let g:ft = ''
+        endif
+    endfu
+<
 
 ==============================================================================
 4. Options                                                    *NERDComOptions*

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -555,6 +555,9 @@ endfunction
 "   -printMsgs: if this is 1 then a message is echoed to the user telling them
 "    if this function changed the delimiters or not
 function s:SwitchToAlternativeDelimiters(printMsgs)
+    if exists('*NERDCommenter_before')
+        exe "call NERDCommenter_before()"
+    endif
     "if both of the alternative delimiters are empty then there is no
     "alternative comment style so bail out
     if b:NERDCommenterDelims['leftAlt'] == '' && b:NERDCommenterDelims['rightAlt'] == ''
@@ -583,6 +586,10 @@ function s:SwitchToAlternativeDelimiters(printMsgs)
     "tell the user what comment delimiters they are now using
     if a:printMsgs
         call s:NerdEcho("Now using " . s:Left() . " " . s:Right() . " to delimit comments", 1)
+    endif
+
+    if exists('*NERDCommenter_after')
+        exe "call NERDCommenter_after()"
     endif
 
     return 1
@@ -1151,6 +1158,10 @@ endfunction
 "    'Minimal', 'Toggle', 'AlignLeft', 'AlignBoth', 'Comment',
 "    'Nested', 'ToEOL', 'Append', 'Insert', 'Uncomment', 'Yank'
 function! NERDComment(mode, type) range
+    if exists('*NERDCommenter_before')
+        exe "call NERDCommenter_before()"
+    endif
+
     let isVisual = a:mode =~ '[vsx]'
 
     if !exists("g:did_load_ftplugin") || g:did_load_ftplugin != 1
@@ -1255,6 +1266,11 @@ function! NERDComment(mode, type) range
     else
         silent! call repeat#set("\<Plug>NERDCommenter". a:type)
     endif
+
+    if exists('*NERDCommenter_after')
+        exe "call NERDCommenter_after()"
+    endif
+
 endfunction
 
 " Function: s:PlaceDelimitersAndInsBetween() function {{{2

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -329,6 +329,7 @@ let s:delimiterMap = {
     \ 'ps1': { 'left': '#' },
     \ 'psf': { 'left': '#' },
     \ 'ptcap': { 'left': '#' },
+    \ 'pug': { 'left': '//-', 'leftAlt': '//' },
     \ 'puppet': { 'left': '#' },
     \ 'pyrex': { 'left': '# ', 'leftAlt': '#' },
     \ 'python': { 'left': '# ', 'leftAlt': '#' },


### PR DESCRIPTION
This is useful when editing files like [vim-vue](https://github.com/xream/vim-vue).

An example: [file-ini2-vim](https://gist.github.com/xream/c474a1adffeb6f70daa6a7ddc22386e0#file-init2-vim).

In hook functions, we can change the filetype, comment and change it back.

I could not come up with any better solution. If there's any better solution, please let me know.

Thank you for this wonderful plugin.