### PR TITLE
Allow commenting empty lines given configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ let g:NERDAltDelims_java = 1
 
 " Add your own custom formats or override the defaults
 let g:NERDCustomDelimiters = { 'c': { 'left': '/**','right': '*/' } }
+
+" Allow commenting and inverting empty lines (useful when commenting a region)
+g:NERDCommentEmptyLines = 1
 ```
 
 ### Default mappings

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -437,6 +437,9 @@ change the filetype back: >
 |'NERDBlockComIgnoreEmpty'|           Forces right delimiters to be placed
                                       when doing visual-block comments.
 
+|'NERDCommentEmptyLines'|             Specifies if empty lines should be
+                                      commented (useful with regions).
+
 |'NERDCommentWholeLinesInVMode'|      Changes behaviour of visual comments.
 
 |'NERDCreateDefaultMappings'|         Turn the default mappings on/off.
@@ -559,6 +562,15 @@ Otherwise, the code block would become: >
     }
     /*}  */
 <
+------------------------------------------------------------------------------
+                                                     *'NERDCommentEmptyLines'*
+Values: 0 or 1.
+Default: 0.
+
+This option affects commenting of empty lines. If this option is turned on,
+then empty lines will be commented as well. Useful when commenting regions of
+code.
+
 ------------------------------------------------------------------------------
                                                 *'NERDCommentWholeLinesInVMode'*
 Values: 0, 1 or 2.

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1465,15 +1465,6 @@ function s:UncommentLines(topLine, bottomLine)
 
 endfunction
 
-" Function: s:TrimTrailingWhitespace(line) {{{2
-" This function removes all the trailing whitespace
-" Args:
-"   -line: the target line
-function s:TrimTrailingWhitespace(line)
-    let toReturn = substitute(a:line, '\s\+$', '', 'g')
-    return toReturn
-endfunction
-
 " Function: s:UncommentLinesSexy(topline, bottomline) {{{2
 " This function removes all the comment characters associated with the sexy
 " comment spanning the given lines
@@ -1519,8 +1510,6 @@ function s:UncommentLinesSexy(topline, bottomline)
         let theLine = s:SwapOuterPlaceHoldersForMultiPartDelims(theLine)
 
         let theLine = s:ConvertLeadingWhiteSpace(theLine)
-
-        let theLine = s:TrimTrailingWhitespace(theLine)
 
         " move onto the next line
         call setline(currentLine, theLine)
@@ -1662,7 +1651,6 @@ function s:UncommentLineNormal(line)
     endif
 
     let line = s:ConvertLeadingWhiteSpace(line)
-    let line = s:TrimTrailingWhitespace(line)
 
     return line
 endfunction

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1465,6 +1465,15 @@ function s:UncommentLines(topLine, bottomLine)
 
 endfunction
 
+" Function: s:TrimTrailingWhitespace(line) {{{2
+" This function removes all the trailing whitespace
+" Args:
+"   -line: the target line
+function s:TrimTrailingWhitespace(line)
+    let toReturn = substitute(a:line, '\s\+$', '', 'g')
+    return toReturn
+endfunction
+
 " Function: s:UncommentLinesSexy(topline, bottomline) {{{2
 " This function removes all the comment characters associated with the sexy
 " comment spanning the given lines
@@ -1510,6 +1519,8 @@ function s:UncommentLinesSexy(topline, bottomline)
         let theLine = s:SwapOuterPlaceHoldersForMultiPartDelims(theLine)
 
         let theLine = s:ConvertLeadingWhiteSpace(theLine)
+
+        let theLine = s:TrimTrailingWhitespace(theLine)
 
         " move onto the next line
         call setline(currentLine, theLine)
@@ -1651,6 +1662,7 @@ function s:UncommentLineNormal(line)
     endif
 
     let line = s:ConvertLeadingWhiteSpace(line)
+    let line = s:TrimTrailingWhitespace(line)
 
     return line
 endfunction
@@ -1810,8 +1822,9 @@ function s:CanToggleCommentLine(forceNested, lineNum)
         return 0
     endif
 
-    " make sure we don't comment lines that are just spaces or tabs or empty.
-    if theLine =~ "^[ \t]*$"
+    " make sure we don't comment lines that are just spaces or tabs or empty,
+    " unless configured otherwise
+    if g:NERDCommentEmptyLines == 0 && theLine =~ "^[ \t]*$"
         return 0
     endif
 


### PR DESCRIPTION
If `g:NERDCommentEmptyLines=1` then it will comment empty line, which is useful when commenting blocks.
When uncommenting it will delete any trailing whitespace.