### PR TITLE
Add option to trim trailing whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ let g:NERDAltDelims_java = 1
 let g:NERDCustomDelimiters = { 'c': { 'left': '/**','right': '*/' } }
 
 " Allow commenting and inverting empty lines (useful when commenting a region)
-g:NERDCommentEmptyLines = 1
+let g:NERDCommentEmptyLines = 1
+
+" Enable trimming of trailing whitespace when uncommenting
+let g:NERDTrimTrailingWhitespace = 1
 ```
 
 ### Default mappings

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -478,6 +478,9 @@ change the filetype back: >
                                       whether to remove them when
                                       uncommenting.
                                       
+|'NERDTrimTrailingWhitespace'|        Specifies if trailing whitespace
+                                      should be deleted when uncommenting.
+
 |'NERDCompactSexyComs'|               Specifies whether to use the compact
                                       style sexy comments.
 
@@ -748,6 +751,15 @@ as opposed to this: >
 If you want spaces to be added then set NERDSpaceDelims to 1 in your vimrc.
 
 See also |'NERDRemoveExtraSpaces'|.
+
+------------------------------------------------------------------------------
+                                                  *'NERDTrimTrailingWhitespace'*
+Values: 0 or 1.
+Default 0.
+
+When uncommenting an empty line some whitespace may be left as a result of
+alignment padding. With this option enabled any trailing whitespace will be
+deleted when uncommenting a line.
 
 ------------------------------------------------------------------------------
                                                              *'NERDDefaultAlign'*

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -64,6 +64,7 @@ call s:InitVariable("g:NERDRemoveExtraSpaces", 0)
 call s:InitVariable("g:NERDRPlace", "<]")
 call s:InitVariable("g:NERDSpaceDelims", 0)
 call s:InitVariable("g:NERDDefaultAlign", "none")
+call s:InitVariable("g:NERDTrimTrailingWhitespace", 0)
 
 let s:NERDFileNameEscape="[]#*$%'\" ?`!&();<>\\"
 
@@ -1419,6 +1420,15 @@ function s:RecoverStateAfterLineComment(state)
     endif
 endfunction
 
+" Function: s:TrimTrailingWhitespace(line) {{{2
+" This function removes all the trailing whitespace
+" Args:
+"   -line: the target line
+function s:TrimTrailingWhitespace(line)
+    let toReturn = substitute(a:line, '\s\+$', '', 'g')
+    return toReturn
+endfunction
+
 " Function: s:UncommentLines(topLine, bottomLine) {{{2
 " This function uncomments the given lines
 "
@@ -1510,6 +1520,10 @@ function s:UncommentLinesSexy(topline, bottomline)
         let theLine = s:SwapOuterPlaceHoldersForMultiPartDelims(theLine)
 
         let theLine = s:ConvertLeadingWhiteSpace(theLine)
+
+        if g:NERDTrimTrailingWhitespace == 1
+            let theLine = s:TrimTrailingWhitespace(theLine)
+        endif
 
         " move onto the next line
         call setline(currentLine, theLine)
@@ -1651,6 +1665,10 @@ function s:UncommentLineNormal(line)
     endif
 
     let line = s:ConvertLeadingWhiteSpace(line)
+
+    if g:NERDTrimTrailingWhitespace == 1
+        let line = s:TrimTrailingWhitespace(line)
+    endif
 
     return line
 endfunction


### PR DESCRIPTION
Add option g:NERDTrimTrailingWhitespace to allow deleting trailing
whitespace when uncommenting a line.