### PR TITLE
add support for turtle (.ttl) files

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -422,6 +422,7 @@ let s:delimiterMap = {
     \ 'tsalt': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'tsscl': { 'left': '#' },
     \ 'tssgm': { 'left': "comment = '", 'right': "'" },
+    \ 'ttl': { 'left': '#' },
     \ 'tup': { 'left': '#' },
     \ 'twig': { 'left': '{#', 'right': '#}' },
     \ 'txt2tags': { 'left': '%' },

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -422,7 +422,7 @@ let s:delimiterMap = {
     \ 'tsalt': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'tsscl': { 'left': '#' },
     \ 'tssgm': { 'left': "comment = '", 'right': "'" },
-    \ 'ttl': { 'left': '# ' },
+    \ 'ttl': { 'left': '#' },
     \ 'tup': { 'left': '#' },
     \ 'twig': { 'left': '{#', 'right': '#}' },
     \ 'txt2tags': { 'left': '%' },

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -422,7 +422,7 @@ let s:delimiterMap = {
     \ 'tsalt': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'tsscl': { 'left': '#' },
     \ 'tssgm': { 'left': "comment = '", 'right': "'" },
-    \ 'ttl': { 'left': '#' },
+    \ 'ttl': { 'left': '# ' },
     \ 'tup': { 'left': '#' },
     \ 'twig': { 'left': '{#', 'right': '#}' },
     \ 'txt2tags': { 'left': '%' },


### PR DESCRIPTION
Turtle format is defined by W3C, and is one of the well-known formats for RDF encoding.

As in Python, comments are simply `#`, and following space is not mandatory, but is to me a readability gain.
