### PR TITLE
Remove trailing whitespace for top and bottom line

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1615,6 +1615,16 @@ function s:UncommentLinesSexy(topline, bottomline)
         let theLine = s:SwapOuterPlaceHoldersForMultiPartDelims(theLine)
         call setline(bottomline, theLine)
     endif
+    
+    " remove trailing whitespaces for first and last line
+    if g:NERDTrimTrailingWhitespace == 1
+        let theLine = getline(a:bottomline)
+        let theLine = s:TrimTrailingWhitespace(theLine)
+        call setline(a:bottomline, theLine)
+        let theLine = getline(a:topline)
+        let theLine = s:TrimTrailingWhitespace(theLine)
+        call setline(a:topline, theLine)
+    endif
 endfunction
 
 " Function: s:UncommentLineNormal(line) {{{2


### PR DESCRIPTION
Remove trailing whitespace for top and bottom line when uncommenting a sexy commented block.
Fixes https://github.com/scrooloose/nerdcommenter/issues/268
