### PR TITLE
add support for M4 macro processor

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -255,6 +255,7 @@ let s:delimiterMap = {
     \ 'lua': { 'left': '--', 'leftAlt': '--[[', 'rightAlt': ']]' },
     \ 'lynx': { 'left': '#' },
     \ 'lytex': { 'left': '%' },
+    \ 'm4': { 'left': 'dnl ' },
     \ 'mail': { 'left': '> ' },
     \ 'mako': { 'left': '##' },
     \ 'man': { 'left': '."' },


### PR DESCRIPTION
M4 knows about two types of ignoring text.  But the concept to which the GNU M4 manual refers to as ["comments"][0] (i.e., lines prefixed with hash signs) is actually telling the interpreter "ignore this text, but pass it to the output".  Most of the time, people don't want the macro comments in their output, so instead the [`dnl` ("discard to next line") macro][1] is usually used for comments in the document-my-thoughts sense.

[0]: https://www.gnu.org/software/m4/manual/m4.html#Comments
[1]: https://www.gnu.org/software/m4/manual/m4.html#Dnl