### PR TITLE
Add support for ansible file type

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -79,6 +79,7 @@ let s:delimiterMap = {
     \ 'amiga': { 'left': ';' },
     \ 'aml': { 'left': '/*' },
     \ 'ampl': { 'left': '#' },
+    \ 'ansible': { 'left': '#' },
     \ 'apache': { 'left': '#' },
     \ 'apachestyle': { 'left': '#' },
     \ 'applescript': { 'left': '--', 'leftAlt': '(*', 'rightAlt': '*)' },


### PR DESCRIPTION
Ansible files are basically YAML with some jinja2 templating, but the commenting is the same as YAML, so a `#` on the left works. This PR adds support for that.

For a syntax plugin I've been using [chase/vim-ansible-yaml](https://github.com/chase/vim-ansible-yaml), but it looks like [pearofducks/ansible-vim](https://github.com/pearofducks/ansible-vim) might be a better choice at this point. Both plugins use the file type `ansible` so this should cover them.