### PR TITLE
space for comments in elixir

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -158,7 +158,7 @@ let s:delimiterMap = {
     \ 'eclass': { 'left': '#' },
     \ 'eiffel': { 'left': '--' },
     \ 'elf': { 'left': "'" },
-    \ 'elixir': { 'left': '#' },
+    \ 'elixir': { 'left': '# ', 'leftAlt': '#' },
     \ 'elm': { 'left': '--' },
     \ 'elmfilt': { 'left': '#' },
     \ 'ember-script': { 'left': '#' },


### PR DESCRIPTION
I think `# ` is better than `#` and that's what I see in most Elixir codes and I think is more preferable https://github.com/elixir-ecto/ecto/blob/master/config/config.exs#L3