### PR TITLE
Add multi-line comments for Elm

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -159,7 +159,7 @@ let s:delimiterMap = {
     \ 'eiffel': { 'left': '--' },
     \ 'elf': { 'left': "'" },
     \ 'elixir': { 'left': '#' },
-    \ 'elm': { 'left': '--' },
+    \ 'elm': { 'left': '--', 'leftAlt': '{--', 'rightAlt': '--}' },
     \ 'elmfilt': { 'left': '#' },
     \ 'ember-script': { 'left': '#' },
     \ 'emblem': { 'left': '/' },
@@ -622,7 +622,7 @@ function s:AppendCommentToLine()
 
     "stick the delimiters down at the end of the line. We have to format the
     "comment with spaces as appropriate
-    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . right 
+    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . right
 
     " if there is a right delimiter then we gotta move the cursor left
     " by the length of the right delimiter so we insert between the delimiters
@@ -1417,7 +1417,7 @@ function s:SetupStateBeforeLineComment(topLine, bottomLine)
     let state = {'foldmethod' : &foldmethod,
                 \'ignorecase' : &ignorecase}
 
-    " Vim's foldmethods are evaluated every time we use 'setline', which can 
+    " Vim's foldmethods are evaluated every time we use 'setline', which can
     " make commenting wide ranges of lines VERY slow. We'll change it to
     " manual, do the commenting stuff and recover it later. To avoid slowing
     " down commenting few lines, we avoid doing this for ranges smaller than
@@ -1622,7 +1622,7 @@ function s:UncommentLinesSexy(topline, bottomline)
         let theLine = s:SwapOuterPlaceHoldersForMultiPartDelims(theLine)
         call setline(bottomline, theLine)
     endif
-    
+
     " remove trailing whitespaces for first and last line
     if g:NERDTrimTrailingWhitespace == 1
         let theLine = getline(a:bottomline)


### PR DESCRIPTION
Technically the minimum necessary syntax for block comments requires
only a single hyphen (`-}`, `{-`), but I have found that using a double
hyphen plays a bit more nicely with the elmcast/elm-vim auto-formatting.
Further, uncommenting when using the single dashes leaves an extra level
of indentation (again, when using elmcast/elm-vim).

-- These are PR (not commit) comments:
Vim auto-removed extra whitespace. Let me know and I can remove those line
changes.

Here's an example of this multi-line comment in action and the resulting
auto-format from elmcast/elm-vim:

```
main : Program Never Model Msg
main =
    Html.program
        { init = ( initialModel, Cmd.none )
        , view = view
        , update = update
        , subscriptions = (\model -> Sub.none)
        }
```
becomes
```
{--
  - main : Program Never Model Msg
  - main =
  -     Html.program
  -         { init = ( initialModel, Cmd.none )
  -         , view = view
  -         , update = update
  -         , subscriptions = (\model -> Sub.none)
  -         }
  --}
```
versus using a single dash:
```
{-
   - main : Program Never Model Msg
   - main =
   -     Html.program
   -         { init = ( initialModel, Cmd.none )
   -         , view = view
   -         , update = update
   -         , subscriptions = (\model -> Sub.none)
   -         }
-}
```