### PR TITLE
Fix removing space when uncommenting spaced AltDelims multipart comment

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -623,7 +623,7 @@ function s:AppendCommentToLine()
 
     "stick the delimiters down at the end of the line. We have to format the
     "comment with spaces as appropriate
-    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . right 
+    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . right
 
     " if there is a right delimiter then we gotta move the cursor left
     " by the length of the right delimiter so we insert between the delimiters
@@ -1396,7 +1396,7 @@ function s:RemoveDelimiters(left, right, line)
 
         "if the user has specified that there is a space before the right delimiter
         "then check for the space and remove it if it is there
-        if delimsSpaced && strpart(line, rightIndx-s:lenSpaceStr, s:lenSpaceStr) == s:spaceStr && s:Multipart()
+        if delimsSpaced && strpart(line, rightIndx-s:lenSpaceStr, s:lenSpaceStr) == s:spaceStr && (s:Multipart() || s:AltMultipart())
             let line = strpart(line, 0, rightIndx-s:lenSpaceStr) . strpart(line, rightIndx)
         endif
     endif
@@ -1418,7 +1418,7 @@ function s:SetupStateBeforeLineComment(topLine, bottomLine)
     let state = {'foldmethod' : &foldmethod,
                 \'ignorecase' : &ignorecase}
 
-    " Vim's foldmethods are evaluated every time we use 'setline', which can 
+    " Vim's foldmethods are evaluated every time we use 'setline', which can
     " make commenting wide ranges of lines VERY slow. We'll change it to
     " manual, do the commenting stuff and recover it later. To avoid slowing
     " down commenting few lines, we avoid doing this for ranges smaller than
@@ -1623,7 +1623,7 @@ function s:UncommentLinesSexy(topline, bottomline)
         let theLine = s:SwapOuterPlaceHoldersForMultiPartDelims(theLine)
         call setline(bottomline, theLine)
     endif
-    
+
     " remove trailing whitespaces for first and last line
     if g:NERDTrimTrailingWhitespace == 1
         let theLine = getline(a:bottomline)


### PR DESCRIPTION
Hello!
When trying to uncomment alternative delimeted comment (with let g:NERDSpaceDelims = 1)
right space don't recognized, cuz s:Mutltipart() checking only primary delims.

![nerdcommenter](https://cloud.githubusercontent.com/assets/7413677/23105961/47ca2e5a-f6ef-11e6-90e3-f6a85a318f9e.gif)
