### PR TITLE
Add support for piglit's shader_test files

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -1093,6 +1093,7 @@ Simon Hengel                        htmlcheetah
 Matt Tolton                         javacc
 Ivan Devat                          javascript.jquery
 tpope                               cucumber,pdf
+Lyude Paul                          piglit shader_test
 ==============================================================================
 10. License                                                   *NERDComLicense*
 

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -373,6 +373,7 @@ let s:delimiterMap = {
     \ 'sgmldecl': { 'left': '--', 'right': '--' },
     \ 'sgmllnx': { 'left': '<!--', 'right': '-->' },
     \ 'sh': { 'left': '#' },
+    \ 'shader_test': { 'left': '#' },
     \ 'sicad': { 'left': '*' },
     \ 'sile': { 'left': '%' },
     \ 'simula': { 'left': '%', 'leftAlt': '--' },


### PR DESCRIPTION
This adds support for shader_test files in piglit, the open source
test suite for OpenGL implementations such as mesa. More information on
piglit can be found at:

https://piglit.freedesktop.org/