### PR TITLE
Bugfix(#296)

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1003,6 +1003,13 @@ function s:CommentLinesSexy(topline, bottomline)
     while currentLine <= a:bottomline + !g:NERDCompactSexyComs
         " get the line and convert the tabs to spaces
         let theLine = getline(currentLine)
+
+        if s:IsCommentedFromStartOfLine("/", theLine) && s:HasCStyleComments() 
+            let comMarker = sexyComMarker . s:spaceStr
+        else
+            let comMarker = sexyComMarkerSpaced
+        endif
+
         let lineHasTabs = s:HasLeadingTabs(theLine)
         if lineHasTabs
             let theLine = s:ConvertLeadingTabsToSpaces(theLine)
@@ -1013,7 +1020,7 @@ function s:CommentLinesSexy(topline, bottomline)
         endif
 
         " add the sexyComMarker
-        let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . sexyComMarkerSpaced . strpart(theLine, leftAlignIndx)
+        let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . comMarker . strpart(theLine, leftAlignIndx)
 
         if lineHasTabs
             let theLine = s:ConvertLeadingSpacesToTabs(theLine)


### PR DESCRIPTION
We FIXED #296 bug Issue in C,C++. 

```
// My comment
some_code_here;
```
If you use  |NERDComSexyComment| when some existing line of code already uses // comment in front of the line, you'll get the below code.

```
/*
*// My comment
*some_code_here
*/
```
Like the above code, it does not comment out the entire code, but rather makes imperfect segments

So while using  |NERDComSexyComment|, if we face the line starting with //, we put space in front of that line

```
/*
* // My comment
*some_code_here
*/
```
like above.

And We also fix this bug when delimit comments are changed by |NERDComAltDelim|.

Although it doesn't look 'sexy' because we put space in only few line,
You can control this because when you put 1 or more number into NERDSpaceDelims, all line will be aligned.