### PR TITLE
Add support for Robot Framework files

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -360,6 +360,7 @@ let s:delimiterMap = {
     \ 'rgb': { 'left': '!' },
     \ 'rib': { 'left': '#' },
     \ 'rmd': { 'left': '#' },
+    \ 'robot': { 'left': '#' },
     \ 'robots': { 'left': '#' },
     \ 'rspec': { 'left': '#' },
     \ 'ruby': { 'left': '#', 'leftAlt': '=begin', 'rightAlt': '=end' },


### PR DESCRIPTION
Add support for [Robot Framework](http://robotframework.org/) test suites.

From the [Robot Framework User Guide](http://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#rules-for-parsing-the-data):

> When Robot Framework parses the test data, it ignores:
>
> * ...
> * All characters following the hash character (#), when it is the first character of a cell. This means that hash marks can be used to enter comments in the test data.
> * ...

...which in general means that a line starting with `#` is regarded as a comment.

To be used with Vim filetype plugins such as https://github.com/mfukar/robotframework-vim, registering the Vim filetype `robot` .