### PR TITLE
Add ToggleSexyComments flag to enable sexy comments while toggling

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ let g:NERDCommentEmptyLines = 1
 
 " Enable trimming of trailing whitespace when uncommenting
 let g:NERDTrimTrailingWhitespace = 1
+
+" Enable Sexy Comments while Toggling. Default behaviour is normal comments.
+let g:ToggleSexyComments = 1
 ```
 
 ### Default mappings

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -65,6 +65,7 @@ call s:InitVariable("g:NERDRPlace", "<]")
 call s:InitVariable("g:NERDSpaceDelims", 0)
 call s:InitVariable("g:NERDDefaultAlign", "none")
 call s:InitVariable("g:NERDTrimTrailingWhitespace", 0)
+call s:InitVariable("g:NERDToggleSexyComments", 0)
 
 let s:NERDFileNameEscape="[]#*$%'\" ?`!&();<>\\"
 
@@ -1261,8 +1262,16 @@ function! NERDComment(mode, type) range
 
         if s:IsInSexyComment(firstLine) || s:IsCommentedFromStartOfLine(s:Left(), theLine) || s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
             call s:UncommentLines(firstLine, lastLine)
-        else
-            call s:CommentLinesToggle(forceNested, firstLine, lastLine)
+		elseif g:NERDToggleSexyComments == 1
+			try
+				call s:CommentLinesSexy(firstLine, lastLine)
+			catch /NERDCommenter.Delimiters/
+				call s:CommentLines(forceNested, g:NERDDefaultAlign, firstLine, lastLine)
+			catch /NERDCommenter.Nesting/
+				call s:NerdEcho("Sexy comment aborted. Nested sexy cannot be nested", 0)
+			endtry
+		else
+			call s:CommentLinesToggle(forceNested, firstLine, lastLine)
         endif
 
     elseif a:type ==? 'Minimal'


### PR DESCRIPTION
Add a flag named "ToggleSexyComments" to use Sexy Comments while toggling.
This is especially useful for people who instead of using a leader key combination to comment, have a 'c' (or some else) key mapped to toggle comments on the selected line(s).

P.S. I am new to open-source and this is my first pull request. Please correct me wherever I'm wrong whether I've violated any style-guide to be followed.