### PR TITLE
add options for NERDCommenterToggle to check all lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ let g:NERDCommentEmptyLines = 1
 
 " Enable trimming of trailing whitespace when uncommenting
 let g:NERDTrimTrailingWhitespace = 1
+
+" Enable NERDCommenterToggle to check all selected lines is commented or not 
+let g:NERDToggleCheckAllLines = 1
 ```
 
 ### Default mappings

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -488,6 +488,9 @@ change the filetype back: >
                                       one of 'none', 'left', 'start', or
                                       'both'.
 
+|'NERDToggleCheckAllLines'|           Enable NERDCommenterToggle to check 
+                                      all selected lines is commented or not.
+
 ------------------------------------------------------------------------------
 4.3 Options details                                    *NERDComOptionsDetails*
 
@@ -799,6 +802,15 @@ Default 1.
 When this option is set to 1, comments are nested automatically. That is, if
 you hit |<Leader>|cc on a line that is already commented it will be commented
 again.
+
+------------------------------------------------------------------------------
+                                                   *'NERDToggleCheckAllLines'*
+Values: 0 or 1.
+Default 0.
+
+When this option is set to 1, NERDCommenterToggle will check all selected line, 
+if there have oneline not be commented, then comment all lines.
+
 
 ------------------------------------------------------------------------------
 3.3 Default delimiter customisation                     *NERDComDefaultDelims*

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -65,6 +65,7 @@ call s:InitVariable("g:NERDRPlace", "<]")
 call s:InitVariable("g:NERDSpaceDelims", 0)
 call s:InitVariable("g:NERDDefaultAlign", "none")
 call s:InitVariable("g:NERDTrimTrailingWhitespace", 0)
+call s:InitVariable("g:NERDToggleCheckAllLines", 0)
 
 let s:NERDFileNameEscape="[]#*$%'\" ?`!&();<>\\"
 
@@ -1258,12 +1259,29 @@ function! NERDComment(mode, type) range
         endtry
 
     elseif a:type ==? 'Toggle'
-        let theLine = getline(firstLine)
-
-        if s:IsInSexyComment(firstLine) || s:IsCommentedFromStartOfLine(s:Left(), theLine) || s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
-            call s:UncommentLines(firstLine, lastLine)
+        if g:NERDToggleCheckAllLines ==# 0
+          let theLine = getline(firstLine)
+          if s:IsInSexyComment(firstLine) || s:IsCommentedFromStartOfLine(s:Left(), theLine) || s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
+              call s:UncommentLines(firstLine, lastLine)
+          else
+              call s:CommentLinesToggle(forceNested, firstLine, lastLine)
+          endif
         else
+          let l:commentAllLines = 0
+          for i in range(firstLine, lastLine)
+            let theLine = getline(i)
+            " if have one line no comment, then comment all lines
+            if !s:IsInSexyComment(firstLine) && !s:IsCommentedFromStartOfLine(s:Left(), theLine) && !s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
+              let l:commentAllLines = 1
+              break
+            else
+          endif
+          endfor
+          if l:commentAllLines ==# 1
             call s:CommentLinesToggle(forceNested, firstLine, lastLine)
+          else
+            call s:UncommentLines(firstLine, lastLine)
+          endif
         endif
 
     elseif a:type ==? 'Minimal'


### PR DESCRIPTION
Sometimes I need to comment a paragraph, but the first line is comment.
So I added an option, the default is 0, as before. 
After set to 1, NERDCommenterToggle will detect each line, if there have oneline not be commented, then comment all lines.