### PR TITLE
Fix ruby comments, totally broken with =begin and =end

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -364,7 +364,7 @@ let s:delimiterMap = {
     \ 'robot': { 'left': '#' },
     \ 'robots': { 'left': '#' },
     \ 'rspec': { 'left': '#' },
-    \ 'ruby': { 'left': '#', 'leftAlt': '=begin', 'rightAlt': '=end' },
+    \ 'ruby': { 'left': '#' },
     \ 'rust': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'sa': { 'left': '--' },
     \ 'samba': { 'left': ';', 'leftAlt': '#' },


### PR DESCRIPTION
It's a fix for: https://github.com/scrooloose/nerdcommenter/issues/306