### PR TITLE
haskell default comment style more idiomatic

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -206,7 +206,7 @@ let s:delimiterMap = {
     \ 'h': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'haml': { 'left': '-#', 'leftAlt': '/' },
     \ 'handlebars': { 'left': '{{!-- ', 'right': ' --}}' },
-    \ 'haskell': { 'left': '--', 'nested': 1, 'leftAlt': '{-', 'rightAlt': '-}', 'nestedAlt': 1 },
+    \ 'haskell': { 'left': '--', 'nested': 0, 'leftAlt': '{-', 'rightAlt': '-}', 'nestedAlt': 1 },
     \ 'haxe': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hb': { 'left': '#' },
     \ 'hbs': { 'left': '{{!-- ', 'right': ' --}}' },

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -206,7 +206,7 @@ let s:delimiterMap = {
     \ 'h': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'haml': { 'left': '-#', 'leftAlt': '/' },
     \ 'handlebars': { 'left': '{{!-- ', 'right': ' --}}' },
-    \ 'haskell': { 'left': '{-', 'right': '-}', 'nested': 1, 'leftAlt': '--', 'nestedAlt': 1 },
+    \ 'haskell': { 'left': '--', 'nested': 1, 'leftAlt': '{-', 'rightAlt': '-}', 'nestedAlt': 1 },
     \ 'haxe': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hb': { 'left': '#' },
     \ 'hbs': { 'left': '{{!-- ', 'right': ' --}}' },


### PR DESCRIPTION
using multi-line comments is uncommon in haskell, and it makes more sense to use multiple single line comments rather than multiple mult-line comments. this changes the default behavior from
```haskell
{- foo :: Int -> Int -}
{- foo a = a + 1 -}

{- bar :: Text -> Text -}
{- bar x = x <> "text" -}
```

to

```haskell
-- foo :: Int -> Int
-- foo a = a + 1

-- bar :: Text -> Text
-- bar x = x <> "text"
```