### PR TITLE
New delimiter for .tf extension

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -431,7 +431,7 @@ let s:delimiterMap = {
     \ 'tex': { 'left': '%' },
     \ 'texinfo': { 'left': "@c " },
     \ 'texmf': { 'left': '%' },
-    \ 'tf': { 'left': ';' },
+    \ 'tf': { 'left': '#' },
     \ 'tidy': { 'left': '#' },
     \ 'tli': { 'left': '#' },
     \ 'tmux': { 'left': '#' },


### PR DESCRIPTION
## What
Replacing the commenting delimiter from a `;` to a `#` for the `.tf`-file extension.

## Why

Autodesk Transcript Files are in popularity not anything near Terraform files and it is hard to find a single Autodesk-tf file on Github. Terraform is a widely used infrastructure definition language and has an large community. Terraform uses `.tf` as file extension and the HCL-language uses `#` to comment out lines.
 