### PR TITLE
make g:NERDToggleCheckAllLines not check blank lines

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -1270,8 +1270,8 @@ function! NERDComment(mode, type) range
           let l:commentAllLines = 0
           for i in range(firstLine, lastLine)
             let theLine = getline(i)
-            " if have one line no comment, then comment all lines
-            if !s:IsInSexyComment(firstLine) && !s:IsCommentedFromStartOfLine(s:Left(), theLine) && !s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
+            " if have one line no comment(not include blank/whitespace-only lines), then comment all lines
+            if theLine =~ '[^ \t]\+' && !s:IsInSexyComment(firstLine) && !s:IsCommentedFromStartOfLine(s:Left(), theLine) && !s:IsCommentedFromStartOfLine(s:Left({'alt': 1}), theLine)
               let l:commentAllLines = 1
               break
             else


### PR DESCRIPTION
Hi, I'm not sure this is a bug or not, but I think my pull request would make a better performance.

Currently, when I set "g:NERDToggleCheckAllLines = 1", if I use `<leader>c<space>`, it would check all my selected lines(including blank lines!), if one of theses lines is not commented, it will comment all lines.

For example:

```Python
# this is the first line

# this is the third line
```

Note that the second line is blank. If I select line 1 to 3, and press `<leader>c<space>`, then the code will become:

```Python
# # this is the first line

# # this is the third line
```

While what I want to do is uncomment line 1 and line 3. I don't think somebody woud like to comment line 1 and line 3 again.

So I made this pull request to let "g:NERDToggleCheckAllLines" not check the blank lines. It should only check the valid lines(I think blank line is not valid lines).

If you think what I changed is better, please accept my pull request.

If you have some other reasons that "g:NERDToggleCheckAllLines" should check all lines include blank lines please tell me why. 

Thank you.

