### PR TITLE
Add spaces to haskell comments

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -207,7 +207,7 @@ let s:delimiterMap = {
     \ 'h': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'haml': { 'left': '-#', 'leftAlt': '/' },
     \ 'handlebars': { 'left': '{{!-- ', 'right': ' --}}' },
-    \ 'haskell': { 'left': '--', 'nested': 0, 'leftAlt': '{-', 'rightAlt': '-}', 'nestedAlt': 1 },
+    \ 'haskell': { 'left': '-- ', 'nested': 0, 'leftAlt': '{- ', 'rightAlt': ' -}', 'nestedAlt': 1 },
     \ 'haxe': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'hb': { 'left': '#' },
     \ 'hbs': { 'left': '{{!-- ', 'right': ' --}}' },


### PR DESCRIPTION
Using `nerdcommenter` to comment out Haskell code is problematic because `--` pre-pended to a bunch of symbols is syntactically valid code.

For example, the line:

```haskell
  -> a
```

gets commented as

```haskell
  ---> a
```

and `--->` can be defined as an operator in haskell, so the line isn't commented out. This commit adds a space before line comments and spaces between alt comments for consistency.