### PR TITLE
Add an option: NERDDisableTabsInBlockComm

### DIFF
--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -811,6 +811,32 @@ Default 0.
 When this option is set to 1, NERDCommenterToggle will check all selected line, 
 if there have oneline not be commented, then comment all lines.
 
+------------------------------------------------------------------------------
+                                                   *'NERDDisableTabsInBlockComm'*
+Values: 0 or 1.
+Default 0.
+
+When this option is set to 1, NERDDisableTabsInBlockComm will not add
+whitespaces align the start location of the ending comment symbol with the end
+location of the starting comment symbol. For example, in Fortran, the new style
+will be as the following,
+
+  close (inpt,iostat=ierr,iomsg=error_message)
+  call io_error(pname,input_fname,2,__LINE__,__FILE__,ierr,error_message)
+
+to
+
+  !===BEGIN===!
+  ! close (inpt,iostat=ierr,iomsg=error_message)
+  ! call io_error(pname,input_fname,2,__LINE__,__FILE__,ierr,error_message)
+  !===END===!
+
+for the block comment style if customized comment symbols are set up in vimrc
+file by the following line
+
+let g:NERDCustomDelimiters = {
+\ 'fortran': { 'left': '!', 'leftAlt':'!===BEGIN===!','rightAlt':'!===END===!'}
+\ }
 
 ------------------------------------------------------------------------------
 3.3 Default delimiter customisation                     *NERDComDefaultDelims*

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -812,31 +812,29 @@ When this option is set to 1, NERDCommenterToggle will check all selected line,
 if there have oneline not be commented, then comment all lines.
 
 ------------------------------------------------------------------------------
-                                                   *'NERDDisableTabsInBlockComm'*
+                                                *'NERDDisableTabsInBlockComm'*
 Values: 0 or 1.
 Default 0.
 
 When this option is set to 1, NERDDisableTabsInBlockComm will not add
-whitespaces align the start location of the ending comment symbol with the end
-location of the starting comment symbol. For example, in Fortran, the new style
-will be as the following,
-
-  close (inpt,iostat=ierr,iomsg=error_message)
-  call io_error(pname,input_fname,2,__LINE__,__FILE__,ierr,error_message)
-
-to
-
-  !===BEGIN===!
-  ! close (inpt,iostat=ierr,iomsg=error_message)
-  ! call io_error(pname,input_fname,2,__LINE__,__FILE__,ierr,error_message)
-  !===END===!
-
+whitespaces align the start location of the ending comment symbol with the
+end location of the starting comment symbol. For example, in Fortran, the new
+style will be as the following: >
+    close (inpt,iostat=ierr,iomsg=error_message)
+    call io_error(pname,input_fname,2,__LINE__,__FILE__,ierr,error_message)
+<
+to >
+    !===BEGIN===!
+    ! close (inpt,iostat=ierr,iomsg=error_message)
+    ! call io_error(pname,input_fname,2,__LINE__,__FILE__,ierr,error_message)
+    !===END===!
+<
 for the block comment style if customized comment symbols are set up in vimrc
-file by the following line
-
-let g:NERDCustomDelimiters = {
-\ 'fortran': { 'left': '!', 'leftAlt':'!===BEGIN===!','rightAlt':'!===END===!'}
-\ }
+file by the following line >
+    let g:NERDCustomDelimiters = {
+    \ 'fortran':{'left':'!','leftAlt':'!===BEGIN===!','rightAlt':'!===END===!'}
+    \ }
+<
 
 ------------------------------------------------------------------------------
 3.3 Default delimiter customisation                     *NERDComDefaultDelims*

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -987,11 +987,13 @@ function s:CommentLinesSexy(topline, bottomline)
         call cursor(a:topline, 1)
         execute 'normal! O'
         let theLine = repeat(' ', leftAlignIndx) . left
+
         " Make sure tabs are respected
         if !&expandtab
            let theLine = s:ConvertLeadingSpacesToTabs(theLine)
         endif
         call setline(a:topline, theLine)
+
         " add the right delimiter after bottom line (we have to add 1 cos we moved
         " the lines down when we added the left delimiter
         call cursor(a:bottomline+1, 1)
@@ -1001,6 +1003,7 @@ function s:CommentLinesSexy(topline, bottomline)
         else
           let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . right
         endif
+
         " Make sure tabs are respected
         if !&expandtab
            let theLine = s:ConvertLeadingSpacesToTabs(theLine)

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -66,6 +66,7 @@ call s:InitVariable("g:NERDSpaceDelims", 0)
 call s:InitVariable("g:NERDDefaultAlign", "none")
 call s:InitVariable("g:NERDTrimTrailingWhitespace", 0)
 call s:InitVariable("g:NERDToggleCheckAllLines", 0)
+call s:InitVariable("g:NERDDisableTabsInBlockComm", 0)
 
 let s:NERDFileNameEscape="[]#*$%'\" ?`!&();<>\\"
 
@@ -986,19 +987,22 @@ function s:CommentLinesSexy(topline, bottomline)
         call cursor(a:topline, 1)
         execute 'normal! O'
         let theLine = repeat(' ', leftAlignIndx) . left
-
         " Make sure tabs are respected
         if !&expandtab
            let theLine = s:ConvertLeadingSpacesToTabs(theLine)
         endif
         call setline(a:topline, theLine)
-
+        " let result = confirm(theLine)
+        " execute "confirm"
         " add the right delimiter after bottom line (we have to add 1 cos we moved
         " the lines down when we added the left delimiter
         call cursor(a:bottomline+1, 1)
         execute 'normal! o'
-        let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . right
-
+        if g:NERDDisableTabsInBlockComm
+          let theLine = repeat(' ', leftAlignIndx) . right
+        else
+          let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . right
+        endif
         " Make sure tabs are respected
         if !&expandtab
            let theLine = s:ConvertLeadingSpacesToTabs(theLine)
@@ -1023,7 +1027,11 @@ function s:CommentLinesSexy(topline, bottomline)
         endif
 
         " add the sexyComMarker
-        let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . sexyComMarkerSpaced . strpart(theLine, leftAlignIndx)
+        if g:NERDDisableTabsInBlockComm
+          let theLine = repeat(' ', leftAlignIndx) . sexyComMarkerSpaced . strpart(theLine, leftAlignIndx)
+        else
+          let theLine = repeat(' ', leftAlignIndx) . repeat(' ', strlen(left)-strlen(sexyComMarker)) . sexyComMarkerSpaced . strpart(theLine, leftAlignIndx)
+        endif
 
         if lineHasTabs
             let theLine = s:ConvertLeadingSpacesToTabs(theLine)

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -992,8 +992,6 @@ function s:CommentLinesSexy(topline, bottomline)
            let theLine = s:ConvertLeadingSpacesToTabs(theLine)
         endif
         call setline(a:topline, theLine)
-        " let result = confirm(theLine)
-        " execute "confirm"
         " add the right delimiter after bottom line (we have to add 1 cos we moved
         " the lines down when we added the left delimiter
         call cursor(a:bottomline+1, 1)


### PR DESCRIPTION
Add an option: NERDDisableTabsInBlockComm. 1 disables adding tabs before the comment symbols in the block style.

This option is probably related to this open issue: https://github.com/scrooloose/nerdcommenter/issues/288