### PR TITLE
Update documentation for 11 year old NERDCommenter[A-Z] style

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,57 +103,57 @@ let g:NERDToggleCheckAllLines = 1
 
 The following key mappings are provided by default (there is also a menu provided that contains menu items corresponding to all the below mappings):
 
-Most of the following mappings are for normal/visual mode only. The **|NERDComInsertComment|** mapping is for insert mode only.
+Most of the following mappings are for normal/visual mode only. The **|NERDCommenterInsert|** mapping is for insert mode only.
 
-  * `[count]<leader>cc` **|NERDComComment|**
+  * `[count]<leader>cc` **|NERDCommenterComment|**
 
     Comment out the current line or text selected in visual mode.
 
-  * `[count]<leader>cn` **|NERDComNestedComment|**
+  * `[count]<leader>cn` **|NERDCommenterNested|**
 
     Same as <leader>cc but forces nesting.
 
-  * `[count]<leader>c<space>` **|NERDComToggleComment|**
+  * `[count]<leader>c<space>` **|NERDCommenterToggle|**
 
     Toggles the comment state of the selected line(s). If the topmost selected line is commented, all selected lines are uncommented and vice versa.
 
-  * `[count]<leader>cm` **|NERDComMinimalComment|**
+  * `[count]<leader>cm` **|NERDCommenterMinimal|**
 
     Comments the given lines using only one set of multipart delimiters.
 
-  * `[count]<leader>ci` **|NERDComInvertComment|**
+  * `[count]<leader>ci` **|NERDCommenterInvert|**
 
     Toggles the comment state of the selected line(s) individually.
 
-  * `[count]<leader>cs` **|NERDComSexyComment|**
+  * `[count]<leader>cs` **|NERDCommenterSexy|**
 
     Comments out the selected lines with a pretty block formatted layout.
 
-  * `[count]<leader>cy` **|NERDComYankComment|**
+  * `[count]<leader>cy` **|NERDCommenterYank|**
 
     Same as <leader>cc except that the commented line(s) are yanked first.
 
-  * `<leader>c$` **|NERDComEOLComment|**
+  * `<leader>c$` **|NERDCommenterToEOL|**
 
     Comments the current line from the cursor to the end of line.
 
-  * `<leader>cA` **|NERDComAppendComment|**
+  * `<leader>cA` **|NERDCommenterAppend|**
 
     Adds comment delimiters to the end of line and goes into insert mode between them.
 
-  * **|NERDComInsertComment|**
+  * **|NERDCommenterInsert|**
 
     Adds comment delimiters at the current cursor position and inserts between. Disabled by default.
 
-  * `<leader>ca` **|NERDComAltDelim|**
+  * `<leader>ca` **|NERDCommenterAltDelims|**
 
     Switches to the alternative set of delimiters.
 
   * `[count]<leader>cl`  
     `[count]<leader>cb` **|NERDComAlignedComment|**
 
-    Same as **|NERDComComment|** except that the delimiters are aligned down the left side (`<leader>cl`) or both sides (`<leader>cb`).
+    Same as **|NERDCommenterComment|** except that the delimiters are aligned down the left side (`<leader>cl`) or both sides (`<leader>cb`).
 
-  * `[count]<leader>cu` **|NERDComUncommentLine|**
+  * `[count]<leader>cu` **|NERDCommenterUncomment|**
 
     Uncomments the selected line(s).

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ Most of the following mappings are for normal/visual mode only. The **|NERDComme
 
     Switches to the alternative set of delimiters.
 
-  * `[count]<leader>cl`  
-    `[count]<leader>cb` **|NERDComAlignedComment|**
+  * `[count]<leader>cl` **|NERDCommenterAlignLeft**
+    `[count]<leader>cb` **|NERDCommenterAlignBoth**
 
     Same as **|NERDCommenterComment|** except that the delimiters are aligned down the left side (`<leader>cl`) or both sides (`<leader>cb`).
 

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -1042,6 +1042,7 @@ JaGoTerr
 Elias Pipping
 mntnoe
 Mark S.
+James P. Harvey
 
 
 Thanks to the following people for sending me new filetypes to support:

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -15,19 +15,19 @@ CONTENTS                                               *NERDCommenterContents*
     3.Functionality provided..................|NERDComFunctionality|
         3.1 Functionality Summary.............|NERDComFunctionalitySummary|
         3.2 Functionality Details.............|NERDComFunctionalityDetails|
-            3.2.1 Comment map.................|NERDComComment|
-            3.2.2 Nested comment map..........|NERDComNestedComment|
-            3.2.3 Toggle comment map..........|NERDComToggleComment|
-            3.2.4 Minimal comment map.........|NERDComMinimalComment|
-            3.2.5 Invert comment map..........|NERDComInvertComment|
-            3.2.6 Sexy comment map............|NERDComSexyComment|
-            3.2.7 Yank comment map............|NERDComYankComment|
-            3.2.8 Comment to EOL map..........|NERDComEOLComment|
-            3.2.9 Append com to line map......|NERDComAppendComment|
-            3.2.10 Insert comment map.........|NERDComInsertComment|
-            3.2.11 Use alternate delims map...|NERDComAltDelim|
+            3.2.1 Comment map.................|NERDCommenterComment|
+            3.2.2 Nested comment map..........|NERDCommenterNested|
+            3.2.3 Toggle comment map..........|NERDCommenterToggle|
+            3.2.4 Minimal comment map.........|NERDCommenterMinimal|
+            3.2.5 Invert comment map..........|NERDCommenterInvert|
+            3.2.6 Sexy comment map............|NERDCommenterSexy|
+            3.2.7 Yank comment map............|NERDCommenterYank|
+            3.2.8 Comment to EOL map..........|NERDCommenterToEOL|
+            3.2.9 Append com to line map......|NERDCommenterAppend|
+            3.2.10 Insert comment map.........|NERDCommenterInsert|
+            3.2.11 Use alternate delims map...|NERDCommenterAltDelims|
             3.2.12 Comment aligned maps.......|NERDComAlignedComment|
-            3.2.13 Uncomment line map.........|NERDComUncommentLine|
+            3.2.13 Uncomment line map.........|NERDCommenterUncomment|
         3.3 Sexy Comments.....................|NERDComSexyComments|
         3.4 The NERDComment function..........|NERDComNERDComment|
         3.5 The Hooks.........................|NERDComHooks|
@@ -84,60 +84,60 @@ See |filetype-plugin-on| for details, but basically, stick this in your vimrc >
 The following key mappings are provided by default (there is also a menu
 with items corresponding to all the mappings below):
 
-[count]|<Leader>|cc |NERDComComment|
+[count]|<Leader>|cc |NERDCommenterComment|
 Comment out the current line or text selected in visual mode.
 
 
-[count]|<Leader>|cn |NERDComNestedComment|
+[count]|<Leader>|cn |NERDCommenterNested|
 Same as |<Leader>|cc but forces nesting.
 
 
-[count]|<Leader>|c<space> |NERDComToggleComment|
+[count]|<Leader>|c<space> |NERDCommenterToggle|
 Toggles the comment state of the selected line(s). If the topmost selected
 line is commented, all selected lines are uncommented and vice versa.
 
 
-[count]|<Leader>|cm |NERDComMinimalComment|
+[count]|<Leader>|cm |NERDCommenterMinimal|
 Comments the given lines using only one set of multipart delimiters.
 
 
-[count]|<Leader>|ci |NERDComInvertComment|
+[count]|<Leader>|ci |NERDCommenterInvert|
 Toggles the comment state of the selected line(s) individually.
 
 
-[count]|<Leader>|cs |NERDComSexyComment|
+[count]|<Leader>|cs |NERDCommenterSexy|
 Comments out the selected lines ``sexily''
 
 
-[count]|<Leader>|cy |NERDComYankComment|
+[count]|<Leader>|cy |NERDCommenterYank|
 Same as |<Leader>|cc except that the commented line(s) are yanked first.
 
 
-|<Leader>|c$ |NERDComEOLComment|
+|<Leader>|c$ |NERDCommenterToEOL|
 Comments the current line from the cursor to the end of line.
 
 
-|<Leader>|cA |NERDComAppendComment|
+|<Leader>|cA |NERDCommenterAppend|
 Adds comment delimiters to the end of line and goes into insert mode between
 them.
 
 
-|NERDComInsertComment|
+|NERDCommenterInsert|
 Adds comment delimiters at the current cursor position and inserts between.
 Disabled by default.
 
 
-|<Leader>|ca |NERDComAltDelim|
+|<Leader>|ca |NERDCommenterAltDelims|
 Switches to the alternative set of delimiters.
 
 
 [count]|<Leader>|cl
 [count]|<Leader>|cb    |NERDComAlignedComment|
-Same as |NERDComComment| except that the delimiters are aligned down the
+Same as |NERDCommenterComment| except that the delimiters are aligned down the
 left side (|<Leader>|cl) or both sides (|<Leader>|cb).
 
 
-[count]|<Leader>|cu |NERDComUncommentLine|
+[count]|<Leader>|cu |NERDCommenterUncomment|
 Uncomments the selected line(s).
 
 
@@ -148,7 +148,7 @@ be repeated via |.|
 3.2 Functionality details                        *NERDComFunctionalityDetails*
 
 ------------------------------------------------------------------------------
-3.2.1 Comment map                                             *NERDComComment*
+3.2.1 Comment map                                       *NERDCommenterComment*
 
 Default mapping: [count]|<Leader>|cc
 Mapped to: <plug>NERDCommenterComment
@@ -164,7 +164,7 @@ If a [count] is given in normal mode, the mapping works as though that many
 lines were selected in visual-line mode.
 
 ------------------------------------------------------------------------------
-3.2.2 Nested comment map                                *NERDComNestedComment*
+3.2.2 Nested comment map                                 *NERDCommenterNested*
 
 Default mapping: [count]|<Leader>|cn
 Mapped to: <plug>NERDCommenterNested
@@ -185,7 +185,7 @@ Related options:
 |'NERDDefaultNesting'|
 
 ------------------------------------------------------------------------------
-3.2.3 Toggle comment map                                *NERDComToggleComment*
+3.2.3 Toggle comment map                                 *NERDCommenterToggle*
 
 Default mapping: [count]|<Leader>|c<space>
 Mapped to: <plug>NERDCommenterToggle
@@ -202,7 +202,7 @@ If a [count] is given in normal mode, the mapping works as though that many
 lines were selected in visual-line mode.
 
 ------------------------------------------------------------------------------
-3.2.4 Minimal comment map                              *NERDComMinimalComment*
+3.2.4 Minimal comment map                               *NERDCommenterMinimal*
 
 Default mapping: [count]|<Leader>|cm
 Mapped to: <plug>NERDCommenterMinimal
@@ -224,7 +224,7 @@ If a [count] is given in normal mode, the mapping works as though that many
 lines were selected in visual-line mode.
 
 ------------------------------------------------------------------------------
-3.2.5 Invert comment map                                *NERDComInvertComment*
+3.2.5 Invert comment map                                 *NERDCommenterInvert*
 
 Default mapping: |<Leader>|ci
 Mapped to: <plug>NERDCommenterInvert
@@ -241,7 +241,7 @@ If a [count] is given in normal mode, the mapping works as though that many
 lines were selected in visual-line mode.
 
 ------------------------------------------------------------------------------
-3.2.6 Sexy comment map                                    *NERDComSexyComment*
+3.2.6 Sexy comment map                                     *NERDCommenterSexy*
 
 Default mapping: [count]|<Leader>|cs
 Mapped to: <plug>NERDCommenterSexy
@@ -261,7 +261,7 @@ Related options:
 |'NERDCompactSexyComs'|
 
 ------------------------------------------------------------------------------
-3.2.7 Yank comment map                                    *NERDComYankComment*
+3.2.7 Yank comment map                                     *NERDCommenterYank*
 
 Default mapping: [count]|<Leader>|cy
 Mapped to: <plug>NERDCommenterYank
@@ -270,7 +270,7 @@ Applicable modes: normal visual visual-line visual-block.
 Same as |<Leader>|cc except that it yanks the line(s) that are commented first.
 
 ------------------------------------------------------------------------------
-3.2.8 Comment to EOL map                                   *NERDComEOLComment*
+3.2.8 Comment to EOL map                                  *NERDCommenterToEOL*
 
 Default mapping: |<Leader>|c$
 Mapped to: <plug>NERDCommenterToEOL
@@ -280,7 +280,7 @@ Comments the current line from the current cursor position up to the end of
 the line.
 
 ------------------------------------------------------------------------------
-3.2.9 Append com to line map                            *NERDComAppendComment*
+3.2.9 Append com to line map                             *NERDCommenterAppend*
 
 Default mapping: |<Leader>|cA
 Mapped to: <plug>NERDCommenterAppend
@@ -290,7 +290,7 @@ Appends comment delimiters to the end of the current line and goes
 to insert mode between the new delimiters.
 
 ------------------------------------------------------------------------------
-3.2.10 Insert comment map                               *NERDComInsertComment*
+3.2.10 Insert comment map                                *NERDCommenterInsert*
 
 Default mapping: disabled by default.
 Map it to: <plug>NERDCommenterInsert
@@ -306,7 +306,7 @@ mapping add >
 to your vimrc.
 
 ------------------------------------------------------------------------------
-3.2.11 Use alternate delims map                              *NERDComAltDelim*
+3.2.11 Use alternate delims map                       *NERDCommenterAltDelims*
 
 Default mapping: |<Leader>|ca
 Mapped to: <plug>NERDCommenterAltDelims
@@ -334,7 +334,7 @@ If a [count] is given in normal mode, the mapping works as though that many
 lines were selected in visual-line mode.
 
 ------------------------------------------------------------------------------
-3.2.13 Uncomment line map                               *NERDComUncommentLine*
+3.2.13 Uncomment line map                             *NERDCommenterUncomment*
 
 Default mapping: [count]|<Leader>|cu
 Mapped to: <plug>NERDCommenterUncomment
@@ -848,13 +848,13 @@ Example: java uses // style comments by default, but you want it to default to
     let g:NERDAltDelims_java = 1
 <
 
-See |NERDComAltDelim| for switching commenting styles at runtime.
+See |NERDCommenterAltDelims| for switching commenting styles at runtime.
 
 ==============================================================================
 5. Key mapping customisation                                *NERDComMappings*
 
 To change a mapping just map another key combo to the internal <plug> mapping.
-For example, to remap the |NERDComComment| mapping to ",omg" you would put
+For example, to remap the |NERDCommenterComment| mapping to ",omg" you would put
 this line in your vimrc: >
     map ,omg <plug>NERDCommenterComment
 <
@@ -990,7 +990,7 @@ The latest dev versions are on github
     - applied a patch from ewfalor to fix an error in the help file with the
       NERDMapleader doc
     - disable the insert mode ctrl-c mapping by default, see :help
-      NERDComInsertComment if you wish to restore it
+      NERDCommenterInsert if you wish to restore it
 
 ==============================================================================
 9. Credits                                                    *NERDComCredits*

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -11,10 +11,10 @@
 CONTENTS                                               *NERDCommenterContents*
 
     1.Intro...................................|NERDCommenter|
-    2.Installation............................|NERDComInstallation|
-    3.Functionality provided..................|NERDComFunctionality|
-        3.1 Functionality Summary.............|NERDComFunctionalitySummary|
-        3.2 Functionality Details.............|NERDComFunctionalityDetails|
+    2.Installation............................|NERDCommenterInstallation|
+    3.Functionality provided..................|NERDCommenterFunctionality|
+        3.1 Functionality Summary.............|NERDCommenterFunctionalitySummary|
+        3.2 Functionality Details.............|NERDCommenterFunctionalityDetails|
             3.2.1 Comment map.................|NERDCommenterComment|
             3.2.2 Nested comment map..........|NERDCommenterNested|
             3.2.3 Toggle comment map..........|NERDCommenterToggle|
@@ -29,21 +29,21 @@ CONTENTS                                               *NERDCommenterContents*
             3.2.12 Comment aligned maps.......|NERDCommenterAlignLeft|
                                               |NERDCommenterAlignBoth|
             3.2.13 Uncomment line map.........|NERDCommenterUncomment|
-        3.3 Sexy Comments.....................|NERDComSexyComments|
-        3.4 The NERDComment function..........|NERDComNERDComment|
-        3.5 The Hooks.........................|NERDComHooks|
-    4.Options.................................|NERDComOptions|
-        4.1 Options summary...................|NERDComOptionsSummary|
-        4.2 Options details...................|NERDComOptionsDetails|
-        4.3 Default delimiter Options.........|NERDComDefaultDelims|
-    5. Customising key mappings...............|NERDComMappings|
-    6. Issues with the script.................|NERDComIssues|
-        6.1 Delimiter detection heuristics....|NERDComHeuristics|
-        6.2 Nesting issues....................|NERDComNesting|
-    7.About..     ............................|NERDComAbout|
-    8.Changelog...............................|NERDComChangelog|
-    9.Credits.................................|NERDComCredits|
-    10.License................................|NERDComLicense|
+        3.3 Sexy Comments.....................|NERDCommenterSexyComments|
+        3.4 The NERDComment function..........|NERDCommenterNERDComment|
+        3.5 The Hooks.........................|NERDCommenterHooks|
+    4.Options.................................|NERDCommenterOptions|
+        4.1 Options summary...................|NERDCommenterOptionsSummary|
+        4.2 Options details...................|NERDCommenterOptionsDetails|
+        4.3 Default delimiter Options.........|NERDCommenterDefaultDelims|
+    5. Customising key mappings...............|NERDCommenterMappings|
+    6. Issues with the script.................|NERDCommenterIssues|
+        6.1 Delimiter detection heuristics....|NERDCommenterHeuristics|
+        6.2 Nesting issues....................|NERDCommenterNesting|
+    7.About..     ............................|NERDCommenterAbout|
+    8.Changelog...............................|NERDCommenterChangelog|
+    9.Credits.................................|NERDCommenterCredits|
+    10.License................................|NERDCommenterLicense|
 
 ==============================================================================
 1. Intro                                                       *NERDCommenter*
@@ -56,7 +56,7 @@ There are also options that allow to tweak the commenting engine to your
 taste.
 
 ==============================================================================
-2. Installation                                          *NERDComInstallation*
+2. Installation                                    *NERDCommenterInstallation*
 
 The NERD Commenter requires Vim 7 or higher.
 
@@ -77,10 +77,10 @@ See |filetype-plugin-on| for details, but basically, stick this in your vimrc >
 <
 
 ==============================================================================
-3. Functionality provided                               *NERDComFunctionality*
+3. Functionality provided                         *NERDCommenterFunctionality*
 
 ------------------------------------------------------------------------------
-3.1 Functionality summary                        *NERDComFunctionalitySummary*
+3.1 Functionality summary                  *NERDCommenterFunctionalitySummary*
 
 The following key mappings are provided by default (there is also a menu
 with items corresponding to all the mappings below):
@@ -146,7 +146,7 @@ With the optional repeat.vim plugin (vimscript #2136), the mappings can also
 be repeated via |.|
 
 ------------------------------------------------------------------------------
-3.2 Functionality details                        *NERDComFunctionalityDetails*
+3.2 Functionality details                  *NERDCommenterFunctionalityDetails*
 
 ------------------------------------------------------------------------------
 3.2.1 Comment map                                       *NERDCommenterComment*
@@ -248,7 +248,7 @@ Default mapping: [count]|<Leader>|cs
 Mapped to: <plug>NERDCommenterSexy
 Applicable modes: normal, visual-line.
 
-Comments the selected line(s) ``sexily''. See |NERDComSexyComments| for
+Comments the selected line(s) ``sexily''. See |NERDCommenterSexyComments| for
 a description of what sexy comments are. Can only be done on filetypes for
 which there is at least one set of multipart comment delimiters specified.
 
@@ -317,7 +317,7 @@ Changes to the alternative commenting style if one is available. For example,
 if the user is editing a c++ file using // comments and they hit |<Leader>|ca
 then they will be switched over to /**/ comments.
 
-See also |NERDComDefaultDelims|
+See also |NERDCommenterDefaultDelims|
 
 ------------------------------------------------------------------------------
 3.2.12 Comment aligned maps                           *NERDCommenterAlignLeft*
@@ -349,7 +349,7 @@ When uncommenting, if the line contains multiple sets of delimiters then the
 ``outermost'' pair of delimiters will be removed.
 
 The script uses a set of heuristics to distinguish ``real'' delimiters from
-``fake'' ones when uncommenting. See |NERDComIssues| for details.
+``fake'' ones when uncommenting. See |NERDCommenterIssues| for details.
 
 If a [count] is given in normal mode, the mapping works as though that many
 lines were selected in visual-line mode.
@@ -359,7 +359,7 @@ Related  options:
 |'NERDRemoveExtraSpaces'|
 
 ------------------------------------------------------------------------------
-3.3 Sexy Comments                                        *NERDComSexyComments*
+3.3 Sexy Comments                                  *NERDCommenterSexyComments*
 These are comments that use one set of multipart comment delimiters as well as
 one other marker symbol. For example: >
     /*
@@ -374,7 +374,7 @@ one other marker symbol. For example: >
 Here the multipart delimiters are /* and */ and the marker is *.
 
 ------------------------------------------------------------------------------
-3.4 The NERDComment function                             *NERDComNERDComment*
+3.4 The NERDComment function                        *NERDCommenterNERDComment*
 
 All of the NERD commenter mappings and menu items invoke a single function
 which delegates the commenting work to other functions. This function is
@@ -395,7 +395,7 @@ For example, if you typed >
 then the script would do a sexy comment on the last visual selection.
 
 ------------------------------------------------------------------------------
-3.5 The hooks                                                   *NERDComHooks*
+3.5 The hooks                                             *NERDCommenterHooks*
 |fu! NERDCommenter_before()|  Before NERDComment/SwitchToAlternativeDelimiters
 |fu! NERDCommenter_after()|    After NERDComment/SwitchToAlternativeDelimiters
 
@@ -425,10 +425,10 @@ change the filetype back: >
 <
 
 ==============================================================================
-4. Options                                                    *NERDComOptions*
+4. Options                                              *NERDCommenterOptions*
 
 ------------------------------------------------------------------------------
-4.1 Options summary                                    *NERDComOptionsSummary*
+4.1 Options summary                              *NERDCommenterOptionsSummary*
 
 |'loaded_nerd_comments'|              Turns off the script.
 
@@ -494,7 +494,7 @@ change the filetype back: >
                                       all selected lines is commented or not.
 
 ------------------------------------------------------------------------------
-4.3 Options details                                    *NERDComOptionsDetails*
+4.3 Options details                              *NERDCommenterOptionsDetails*
 
 To enable any of the below options you should put the given line in your
 ~/.vimrc
@@ -628,7 +628,7 @@ Default: 1.
 
 If set to 0, none of the default mappings will be created.
 
-See also |NERDComMappings|.
+See also |NERDCommenterMappings|.
 
 ------------------------------------------------------------------------------
                                                       *'NERDCustomDelimiters'*
@@ -839,7 +839,7 @@ file by the following line >
 <
 
 ------------------------------------------------------------------------------
-3.3 Default delimiter customisation                     *NERDComDefaultDelims*
+3.3 Default delimiter customisation               *NERDCommenterDefaultDelims*
 
 If you want the NERD commenter to use the alternative delimiters for a
 specific filetype by default then put a line of this form into your vimrc: >
@@ -853,7 +853,7 @@ Example: java uses // style comments by default, but you want it to default to
 See |NERDCommenterAltDelims| for switching commenting styles at runtime.
 
 ==============================================================================
-5. Key mapping customisation                                *NERDComMappings*
+5. Key mapping customisation                           *NERDCommenterMappings*
 
 To change a mapping just map another key combo to the internal <plug> mapping.
 For example, to remap the |NERDCommenterComment| mapping to ",omg" you would put
@@ -868,11 +868,11 @@ map to.
 See also |'NERDCreateDefaultMappings'|.
 
 ==============================================================================
-6. Issues with the script                                      *NERDComIssues*
+6. Issues with the script                                *NERDCommenterIssues*
 
 
 ------------------------------------------------------------------------------
-6.1 Delimiter detection heuristics                         *NERDComHeuristics*
+6.1 Delimiter detection heuristics                   *NERDCommenterHeuristics*
 
 Heuristics are used to distinguish the real comment delimiters
 
@@ -892,7 +892,7 @@ string. These heuristics, while usually pretty accurate, will not work for all
 cases.
 
 ------------------------------------------------------------------------------
-6.2 Nesting issues                                            *NERDComNesting*
+6.2 Nesting issues                                      *NERDCommenterNesting*
 
 If we have some line of code like this: >
     /*int foo */ = /*5 + 9;*/
@@ -912,7 +912,7 @@ will become: >
 for simplicity)
 
 ==============================================================================
-7. About                                                        *NERDComAbout*
+7. About                                                  *NERDCommenterAbout*
 
 The author of the NERD commenter is Martyzillatron --- the half robot, half
 dinosaur bastard son of Megatron and Godzilla. He enjoys destroying
@@ -929,7 +929,7 @@ The latest dev versions are on github
     http://github.com/scrooloose/nerdcommenter
 
 ==============================================================================
-8. Changelog                                                *NERDComChangelog*
+8. Changelog                                          *NERDCommenterChangelog*
 
 2.3.0
     - remove all filetypes which have a &commentstring in the standard vim
@@ -995,7 +995,7 @@ The latest dev versions are on github
       NERDCommenterInsert if you wish to restore it
 
 ==============================================================================
-9. Credits                                                    *NERDComCredits*
+9. Credits                                              *NERDCommenterCredits*
 
 Thanks to the follow people for suggestions and patches:
 
@@ -1133,7 +1133,7 @@ Ivan Devat                          javascript.jquery
 tpope                               cucumber,pdf
 Lyude Paul                          piglit shader_test
 ==============================================================================
-10. License                                                   *NERDComLicense*
+10. License                                             *NERDCommenterLicense*
 
 The NERD commenter is released under the wtfpl.
 See http://sam.zoy.org/wtfpl/COPYING.

--- a/doc/NERD_commenter.txt
+++ b/doc/NERD_commenter.txt
@@ -26,7 +26,8 @@ CONTENTS                                               *NERDCommenterContents*
             3.2.9 Append com to line map......|NERDCommenterAppend|
             3.2.10 Insert comment map.........|NERDCommenterInsert|
             3.2.11 Use alternate delims map...|NERDCommenterAltDelims|
-            3.2.12 Comment aligned maps.......|NERDComAlignedComment|
+            3.2.12 Comment aligned maps.......|NERDCommenterAlignLeft|
+                                              |NERDCommenterAlignBoth|
             3.2.13 Uncomment line map.........|NERDCommenterUncomment|
         3.3 Sexy Comments.....................|NERDComSexyComments|
         3.4 The NERDComment function..........|NERDComNERDComment|
@@ -131,8 +132,8 @@ Disabled by default.
 Switches to the alternative set of delimiters.
 
 
-[count]|<Leader>|cl
-[count]|<Leader>|cb    |NERDComAlignedComment|
+[count]|<Leader>|cl    |NERDCommenterAlignLeft|
+[count]|<Leader>|cb    |NERDCommenterAlignBoth|
 Same as |NERDCommenterComment| except that the delimiters are aligned down the
 left side (|<Leader>|cl) or both sides (|<Leader>|cb).
 
@@ -319,7 +320,8 @@ then they will be switched over to /**/ comments.
 See also |NERDComDefaultDelims|
 
 ------------------------------------------------------------------------------
-3.2.12 Comment aligned maps                            *NERDComAlignedComment*
+3.2.12 Comment aligned maps                           *NERDCommenterAlignLeft*
+                                                      *NERDCommenterAlignBoth*
 
 Default mappings: [count]|<Leader>|cl   [count]|<Leader>|cb
 Mapped to: <plug>NERDCommenterAlignLeft


### PR DESCRIPTION
11 years ago, b54d3bb renamed `NERDCom[A-Z]` mappings to `<plug>NERDCommenter[A-Z]` mappings.  (Unknown if intentional.)  But, the docs were never updated.  When README.md was later created, it kept the old `NERDCom[A-Z]` names.

Without these changes, it can be quite confusing to someone trying to setup their own mappings, and having nothing work!  Found a few previous issues that look like they were caused by this confusion.

I don't know if splitting the `NERDCommenterAlign{Left,Both}` tags as in the second commit is customary, but it works and still avoids having two separate help sections.  I don't feel replacing `NERDComAlignedComment` with `NERDCommenterAlignedComment` is the proper fix here, because someone searching for a `NERDCommenterAlign{Left,Both}` tag isn't going to find it.

Also update other help tags from `NERDCom[A-Z]` pattern to `NERDCommenter[A-Z]` for consistency.