### PR TITLE
Improve handling of delimiters with backslashes

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -2070,6 +2070,14 @@ function s:FindDelimiterIndex(delimiter, line)
     "get the index of the first occurrence of the delimiter
     let delIndx = stridx(a:line, l:delimiter)
 
+    "if there is no match and the delimiter contains two backslashes
+    "then try indexing again but replace those backslashes with only a
+    "single backslash on the assumption that the two backslashes really
+    "are an escape for a single backslash
+    if delIndx == -1 && stridx(l:delimiter, '\\') > 0
+        let delIndx = stridx(a:line, substitute(l:delimiter, '\\\\', '\', ''))
+    endif
+
     "keep looping thru the line till we either find a real comment delimiter
     "or run off the EOL
     while delIndx != -1


### PR DESCRIPTION
This pull request has been opened to address issue https://github.com/scrooloose/nerdcommenter/issues/402 I raised separately.

As mentioned in the issue description, I recently added delimiter definitions for troff family languages, which included, for the first time backslashes:

```viml
\# 	" groff
.\" 	" troff / man doc
```

...but these aren't handled correctly in some cases. Currently the plugin can add them but they won't be detected when trying to remove them, so they get added again.

This pull request is trying to solve this, although it might not be in the best way and others may have a better solution to this, but of course if I can contribute then I'll try to.