### PR TITLE
Adds New Delimiter for Hashicorp Sentinel Files

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -388,6 +388,7 @@ let s:delimiterMap = {
     \ 'scss': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'sdc': { 'left': '#' },
     \ 'sed': { 'left': '#' },
+    \ 'sentinel': { 'left': '#', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'sgmldecl': { 'left': '--', 'right': '--' },
     \ 'sgmllnx': { 'left': '<!--', 'right': '-->' },
     \ 'sh': { 'left': '#' },


### PR DESCRIPTION
- Sentinel is a new language developed by Hashicorp
- Sentinel supports three types of comments, `#` and `//` for single
  line comments and `/* ... */` for multi-line comments as described
  in their documentation - https://docs.hashicorp.com/sentinel/language/spec/#comments
  - Since sentinel and terraform, .tf extension, are related, the `#`
    symbol was chosen to keep in line with the tf single line comment