### PR TITLE
Add semantic patch (.cocci) to delimiterMap

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -123,6 +123,7 @@ let s:delimiterMap = {
     \ 'clipper': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'clojure': { 'left': ';' },
     \ 'cmake': { 'left': '#' },
+    \ 'cocci': { 'left': '//' },
     \ 'coffee': { 'left': '#', 'leftAlt': '###', 'rightAlt': '###' },
     \ 'conkyrc': { 'left': '#' },
     \ 'context': { 'left': '%', 'leftAlt': '--' },


### PR DESCRIPTION
Coccinelle is a tool used for transforming C source code. It
uses the Semantic Patch Language (.cocci files) for doing this.
The conventional notation for commenting in semantic patches
is "//".

Used in conjunction with this plugin:

https://github.com/ahf/cocci-syntax

The cocci filetype is set, following which NERD_commenter can
be used in .cocci files.

Signed-off-by: Jaskaran Singh <jaskaransingh7654321@gmail.com>